### PR TITLE
fix: 尝试修复频繁进入退出导致的崩溃

### DIFF
--- a/libimageviewer/service/imagedataservice.h
+++ b/libimageviewer/service/imagedataservice.h
@@ -63,6 +63,10 @@ public:
     //
     void setVisualIndex(int row);
     int getVisualIndex();
+
+    //取消图片加载
+    void stopReadThumbnail();
+
 private slots:
 signals:
     void sigeUpdateListview();
@@ -78,6 +82,9 @@ private:
     QMap<QString, QString> m_movieDurationStrMap;
     QQueue<QString> m_imageKeys;
     int m_visualIndex = 0;//用户查找视图中的model index
+
+    //图片读取线程
+    std::vector<LibReadThumbnailThread *> readThreadGroup;
 };
 
 
@@ -100,7 +107,7 @@ public:
 protected:
     void run() override;
 private:
-    bool m_quit = false;
+    std::atomic_bool m_quit;
 
 };
 #endif // IMAGEDATASERVICE_H

--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -52,6 +52,7 @@
 #include "service/ocrinterface.h"
 #include "slideshow/slideshowpanel.h"
 #include "service/configsetter.h"
+#include "service/imagedataservice.h"
 
 const QString IMAGE_TMPPATH =   QDir::homePath() +
                                 "/.config/deepin/deepin-image-viewer/";
@@ -2046,6 +2047,8 @@ void LibViewPanel::hideEvent(QHideEvent *e)
         m_info->setVisible(false);
         m_extensionPanel->setVisible(false);
     }
+
+    LibImageDataService::instance()->stopReadThumbnail();
 
     QFrame::hideEvent(e);
 }


### PR DESCRIPTION
从日志上看是图片加载队列炸了
目前修改为当界面退出时停止全部加载队列，重新进入界面后再重启队列

Log: 尝试修复频繁进入退出导致的崩溃
Bug: https://pms.uniontech.com/bug-view-135425.html