### PR TITLE
fix: 修复相册最小尺寸下,大图展示时缩略图未显示的问题

### DIFF
--- a/libimageviewer/viewpanel/contents/bottomtoolbar.cpp
+++ b/libimageviewer/viewpanel/contents/bottomtoolbar.cpp
@@ -70,7 +70,7 @@ const int THUMBNAIL_WIDTH = 32;
 const int THUMBNAIL_ADD_WIDTH = 32;
 const int THUMBNAIL_LIST_ADJUST = 9;
 const int THUMBNAIL_VIEW_DVALUE = 668;
-
+const int MAINWINDOW_MIN_WIDTH = 630;
 const int LOAD_LEFT_RIGHT = 25;     //前后加载图片数（动态）
 
 }  // namespace
@@ -543,6 +543,18 @@ void LibBottomToolbar::onThumbnailChanged(QPixmap pix, const QSize &originalSize
 void LibBottomToolbar::resizeEvent(QResizeEvent *event)
 {
     Q_UNUSED(event);
+
+    if (LibCommonService::instance()->getImgViewerType() == imageViewerSpace::ImgViewerType::ImgViewerTypeAlbum
+            && m_imgListWidget->isVisible()) {
+        if ((topLevelWidget()->width() - MAINWINDOW_MIN_WIDTH) < (ICON_SIZE.width() * 2)) {
+            m_rotateRBtn->setVisible(false);
+            m_rotateLBtn->setVisible(false);
+        } else {
+            m_rotateRBtn->setVisible(true);
+            m_rotateLBtn->setVisible(true);
+        }
+    }
+
     emit sigResizeBottom();
     m_imgListWidget->moveCenterWidget();
 }
@@ -550,6 +562,18 @@ void LibBottomToolbar::resizeEvent(QResizeEvent *event)
 void LibBottomToolbar::showEvent(QShowEvent *event)
 {
     Q_UNUSED(event);
+
+    if (LibCommonService::instance()->getImgViewerType() == imageViewerSpace::ImgViewerType::ImgViewerTypeAlbum
+            && m_imgListWidget->isVisible()) {
+        if ((topLevelWidget()->width() - MAINWINDOW_MIN_WIDTH) < (ICON_SIZE.width() * 2)) {
+            m_rotateRBtn->setVisible(false);
+            m_rotateLBtn->setVisible(false);
+        } else {
+            m_rotateRBtn->setVisible(true);
+            m_rotateLBtn->setVisible(true);
+        }
+    }
+
     m_imgListWidget->moveCenterWidget();
 }
 


### PR DESCRIPTION
Description: 显示控件不足时，优先隐藏左、右旋转按钮，以便显示缩略图按钮

Log: 修复相册最小尺寸下，大图展示时缩略图未显示的问题

Bug: https://pms.uniontech.com/bug-view-130281.html