### PR TITLE
fix: 修复看图因为切换图片导致内存上涨不降的问题

### DIFF
--- a/libimageviewer/unionimage/unionimage.cpp
+++ b/libimageviewer/unionimage/unionimage.cpp
@@ -1592,6 +1592,30 @@ QString PrivateDetectImageFormat(const QString &filepath)
     return "";
 }
 
+QPixmap cropThumbnail(const QPixmap &pix , int size){
+    QPixmap rePixmap;
+    if (0 != pix.height() && 0 != pix.width() && (pix.height() / pix.width()) < 10 && (pix.width() / pix.height()) < 10) {
+        bool cache_exist = false;
+        if (pix.height() != size && pix.width() != size) {
+            if (pix.height() >= pix.width()) {
+                cache_exist = true;
+                rePixmap = pix.scaledToWidth(size,  Qt::FastTransformation);
+            } else if (pix.height() <= pix.width()) {
+                cache_exist = true;
+                rePixmap = pix.scaledToHeight(size,  Qt::FastTransformation);
+            }
+        }
+        if (!cache_exist) {
+            if (static_cast<float>(pix.height()) / static_cast<float>(pix.width()) > 3) {
+                rePixmap = pix.scaledToWidth(size,  Qt::FastTransformation);
+            } else {
+                rePixmap = pix.scaledToHeight(size,  Qt::FastTransformation);
+            }
+        }
+    }
+    return rePixmap;
+}
+
 };
 
 

--- a/libimageviewer/unionimage/unionimage.h
+++ b/libimageviewer/unionimage/unionimage.h
@@ -209,7 +209,14 @@ UNIONIMAGESHARED_EXPORT imageViewerSpace::ImageType getImageType(const QString &
  */
 UNIONIMAGESHARED_EXPORT imageViewerSpace::PathType getPathType(const QString &imagepath);
 
-
+/**
+ * @brief CropThumbnail
+ * @param pixmap
+ * @author LMH
+ * @return pixmap
+ * 获得缩略图
+ */
+UNIONIMAGESHARED_EXPORT QPixmap cropThumbnail(const QPixmap &pix , int size = 200);
 
 QT_BEGIN_NAMESPACE
 

--- a/libimageviewer/viewpanel/scen/imagegraphicsview.cpp
+++ b/libimageviewer/viewpanel/scen/imagegraphicsview.cpp
@@ -55,7 +55,6 @@
 #include <DGuiApplicationHelper>
 #include <DApplicationHelper>
 
-
 #ifndef QT_NO_OPENGL
 //#include <QGLWidget>
 #endif
@@ -914,7 +913,7 @@ bool LibImageGraphicsView::slotRotatePixmap(int nAngel)
     autoFit();
     m_rotateAngel += nAngel;
 
-    emit currentThumbnailChanged(pixmap, pixmap.size());
+    emit currentThumbnailChanged(LibUnionImage_NameSpace::cropThumbnail(pixmap), pixmap.size());
     emit imageChanged(m_path);
     return true;
 }
@@ -1154,7 +1153,6 @@ void LibImageGraphicsView::onCacheFinish()
             if (!m_pixmapItem) {
                 return;
             }
-
             QPixmap pixmap = vl.last().value<QPixmap>();
             QPixmap tmpPixmap = pixmap;
             tmpPixmap.setDevicePixelRatio(devicePixelRatioF());
@@ -1167,7 +1165,6 @@ void LibImageGraphicsView::onCacheFinish()
                 pixmap = pixmap.transformed(rotate, Qt::SmoothTransformation);
                 m_newImageRotateAngle = 0;
             }
-
             m_pixmapItem->setGraphicsEffect(nullptr);
             m_pixmapItem->setPixmap(pixmap);
             setSceneRect(m_pixmapItem->boundingRect());
@@ -1175,10 +1172,9 @@ void LibImageGraphicsView::onCacheFinish()
             emit imageChanged(path);
             this->update();
             m_newImageLoadPhase = FullFinish;
-
             //刷新缩略图
             if (!pixmap.isNull()) {
-                emit currentThumbnailChanged(pixmap, pixmap.size());
+                emit currentThumbnailChanged(LibUnionImage_NameSpace::cropThumbnail(pixmap), pixmap.size());
             }
 
         }
@@ -1327,6 +1323,7 @@ void LibImageGraphicsView::pinchTriggered(QPinchGesture *gesture)
 
 void LibImageGraphicsView::OnFinishPinchAnimal()
 {
+
     m_rotateflag = true;
     m_bnextflag = true;
     m_rotateAngelTouch = 0;
@@ -1363,7 +1360,7 @@ void LibImageGraphicsView::OnFinishPinchAnimal()
         m_rotateAngel += m_endvalue;
         if (m_endvalue > 0) {
             emit gestureRotate(static_cast<int>(0));
-            emit currentThumbnailChanged(pixmap, pixmap.size());
+            emit currentThumbnailChanged(LibUnionImage_NameSpace::cropThumbnail(pixmap), pixmap.size());
             emit UpdateNavImg();
         }
     }

--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -111,7 +111,7 @@ LibViewPanel::LibViewPanel(AbstractTopToolbar *customToolbar, QWidget *parent)
     setAcceptDrops(true);
 //    initExtensionPanel();
 
-    QObject::connect(m_view, &LibImageGraphicsView::currentThumbnailChanged, m_bottomToolbar, &LibBottomToolbar::onThumbnailChanged);
+    QObject::connect(m_view, &LibImageGraphicsView::currentThumbnailChanged, m_bottomToolbar, &LibBottomToolbar::onThumbnailChanged,Qt::DirectConnection);
     QObject::connect(m_view, &LibImageGraphicsView::gestureRotate, this, &LibViewPanel::slotRotateImage);
 }
 


### PR DESCRIPTION
Description: 修复看图因为切换图片导致内存上涨不降的问题，由于每次发送缩略图变更是发送的原图，所以导致内存居高不下

Log: 修复看图因为切换图片导致内存上涨不降的问题