### PR TITLE
fix: 修复单元测试崩溃

### DIFF
--- a/libimageviewer/service/imagedataservice.cpp
+++ b/libimageviewer/service/imagedataservice.cpp
@@ -190,16 +190,18 @@ LibImageDataService::LibImageDataService(QObject *parent)
 
 void LibImageDataService::stopReadThumbnail()
 {
-    for (auto &thread : readThreadGroup) {
-        thread->setQuit(true);
-    }
+    if (!readThreadGroup.empty()) {
+        for (auto &thread : readThreadGroup) {
+            thread->setQuit(true);
+        }
 
-    for (auto &thread : readThreadGroup) {
-        while (thread->isRunning());
-        thread->deleteLater();
-    }
+        for (auto &thread : readThreadGroup) {
+            while (thread->isRunning());
+            thread->deleteLater();
+        }
 
-    readThreadGroup.clear();
+        readThreadGroup.clear();
+    }
 }
 
 //缩略图读取线程

--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -111,18 +111,19 @@ LibViewPanel::LibViewPanel(AbstractTopToolbar *customToolbar, QWidget *parent)
     setAcceptDrops(true);
 //    initExtensionPanel();
 
-    QObject::connect(m_view, &LibImageGraphicsView::currentThumbnailChanged, m_bottomToolbar, &LibBottomToolbar::onThumbnailChanged,Qt::DirectConnection);
+    QObject::connect(m_view, &LibImageGraphicsView::currentThumbnailChanged, m_bottomToolbar, &LibBottomToolbar::onThumbnailChanged, Qt::DirectConnection);
     QObject::connect(m_view, &LibImageGraphicsView::gestureRotate, this, &LibViewPanel::slotRotateImage);
 
     //删除完了图片需要返回原状bug137195
-    QObject::connect(ImageEngine::instance(), &ImageEngine::sigPicCountIsNull, this,[=]{
-        if (ImgViewerType::ImgViewerTypeAlbum != LibCommonService::instance()->getImgViewerType()) {
-            if(window()->isFullScreen()){
+    QObject::connect(ImageEngine::instance(), &ImageEngine::sigPicCountIsNull, this, [ = ] {
+        if (ImgViewerType::ImgViewerTypeAlbum != LibCommonService::instance()->getImgViewerType())
+        {
+            if (window()->isFullScreen()) {
                 window()->showNormal();
                 window()->resize(m_windowSize);
-                window()->move(m_windowX,m_windowY);
-                QTimer::singleShot(50,[=]{
-                    window()->move(m_windowX,m_windowY);
+                window()->move(m_windowX, m_windowY);
+                QTimer::singleShot(50, [ = ] {
+                    window()->move(m_windowX, m_windowY);
                 });
             }
         }

--- a/tests/gtestview.cpp
+++ b/tests/gtestview.cpp
@@ -331,7 +331,6 @@ TEST_F(gtestview, LibImageDataService)
     LibImageDataService::instance()->getCount();
     LibImageDataService::instance()->setVisualIndex(0);
     LibImageDataService::instance()->addMovieDurationStr("", "");
-    LibImageDataService::instance()->deleteLater();
 
     QTest::qWait(500);
 


### PR DESCRIPTION
原因是单元测试中存在主动析构单例的代码，导致最近新加的部分代码崩溃
解决方法是删除这部分代码

Log: 修复单元测试崩溃