### PR TITLE
fix: 修复bug138877

### DIFF
--- a/libimageviewer/service/imagedataservice.cpp
+++ b/libimageviewer/service/imagedataservice.cpp
@@ -259,6 +259,9 @@ void LibReadThumbnailThread::readThumbnail(QString path)
             }
         }
     }
+    else {
+        tImg = tImg.scaled(200,200);
+    }
 
     itemInfo.image = tImg;
 

--- a/libimageviewer/viewpanel/scen/imagegraphicsview.cpp
+++ b/libimageviewer/viewpanel/scen/imagegraphicsview.cpp
@@ -1214,6 +1214,9 @@ void LibImageGraphicsView::onCacheFinish()
                         }
                     }
                 }
+                else {
+                    thumbnailPixmap = pixmap.scaled(200,200);
+                }
                 emit currentThumbnailChanged(thumbnailPixmap, pixmap.size());
             }
 


### PR DESCRIPTION
Description: 修复bug138877,由于刷新的时候尺寸有问题的图片直接变为撕裂图了,现在裁剪为200,200

Log: 与裁剪有关
Bug: https://pms.uniontech.com/bug-view-138877.html