### PR TITLE
fix: 修复看图先最大化再切换至全屏，鼠标唤起工具栏的时候也会唤起顶部标题栏

### DIFF
--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -128,6 +128,11 @@ LibViewPanel::LibViewPanel(AbstractTopToolbar *customToolbar, QWidget *parent)
             }
         }
     });
+
+    // 添加过滤处理，当窗口出现状态变更时(最大化、全屏)，处理标题栏隐藏、显示
+    if (window()) {
+        window()->installEventFilter(this);
+    }
 }
 
 LibViewPanel::~LibViewPanel()
@@ -2070,4 +2075,24 @@ void LibViewPanel::hideEvent(QHideEvent *e)
     LibImageDataService::instance()->stopReadThumbnail();
 
     QFrame::hideEvent(e);
+}
+
+bool LibViewPanel::eventFilter(QObject *o, QEvent *e)
+{
+    // 判断是否为窗口的状态变化
+    if (window() == o
+            && QEvent::WindowStateChange == e->type()) {
+        if (m_topToolbar) {
+            if (window()->isFullScreen()) {
+                // 全屏状态下隐藏标题栏
+                m_topToolbar->setVisible(false);
+            } else {
+                if (!m_topToolBarIsAlwaysHide) {
+                    m_topToolbar->setVisible(true);
+                }
+            }
+        }
+    }
+
+    return QFrame::eventFilter(o, e);
 }

--- a/libimageviewer/viewpanel/viewpanel.h
+++ b/libimageviewer/viewpanel/viewpanel.h
@@ -207,6 +207,10 @@ protected:
     void leaveEvent(QEvent *event) override;
 
     void hideEvent(QHideEvent *e) override;
+
+    // 捕获窗口的状态变更事件
+    bool eventFilter(QObject *o, QEvent *e) override;
+
 signals:
     void imageChanged(const QString &path);
 


### PR DESCRIPTION
Description: 在多屏下，由于无桌面工具栏，窗口在全屏和最大化时控件大小未变更，旧版代码没有捕获大小变更事件，导致未处理标题栏隐藏，添加事件过滤捕获窗口状态变更事件，主动隐藏标题栏。

Log: 修复看图先最大化再切换至全屏，鼠标唤起工具栏的时候也会唤起顶部标题栏
Bug: https://pms.uniontech.com/bug-view-124991.html
Influence: 标题栏