### PR TITLE
fix: 添加双引擎视频解析库以解决缩略图不一致和速度慢

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 11), cmake, qtbase5-dev, pkg-config,libexif-dev, li
  qtmultimedia5-dev, x11proto-xext-dev, libmtdev-dev, libegl1-mesa-dev,
  libudev-dev, libfontconfig1-dev, libfreetype6-dev, libglib2.0-dev,
  libxrender-dev, libdtkwidget-dev, libdtkwidget5-bin,libdtkcore5-bin,libgio-qt-dev,libudisks2-qt5-dev,
- libopencv-dev
+ libopencv-dev, libgstreamer1.0-dev, libmediainfo-dev
 Standards-Version: 3.9.8
 Homepage: http://www.deepin.org
 
@@ -18,7 +18,7 @@ Conflicts:
  libimage-viewer
 Replaces:
  libimage-viewer
-Recommends: libqt5libqgtk2, kimageformat-plugins ,deepin-ocr
+Recommends: libqt5libqgtk2, kimageformat-plugins, deepin-ocr, ffmpegthumbnailer, ffmpeg
 Description: Image Viewer library.
  Deepin Image Viewer library.
 

--- a/libimageviewer/CMakeLists.txt
+++ b/libimageviewer/CMakeLists.txt
@@ -39,6 +39,9 @@ pkg_check_modules(3rd_lib REQUIRED
     dtkwidget
     dtkcore
     dtkgui
+    glib-2.0
+    gstreamer-1.0
+    libmediainfo
     )
 
 #需要打开的头文件
@@ -102,6 +105,7 @@ install(FILES
     imageengine.h
     imageviewer.h
     image-viewer_global.h
+    movieservice.h
     DESTINATION include/libimageviewer)
 
 install(FILES ${PROJECT_BINARY_DIR}/libimageviewer.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/libimageviewer/movieservice.cpp
+++ b/libimageviewer/movieservice.cpp
@@ -1,0 +1,559 @@
+/*
+ * Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     ZhangYong <zhangyong@uniontech.com>
+ *
+ * Maintainer: ZhangYong <ZhangYong@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "movieservice.h"
+#include <QMetaType>
+#include <QDirIterator>
+#include <memory>
+#include <deque>
+#include <MediaInfoDLL/MediaInfoDLL.h>
+#include <QProcess>
+#include <QtDebug>
+#include "service/gstreamervideothumbnailer.h"
+
+#include <iostream>
+
+#define SEEK_TIME "00:00:01"
+
+MovieService *MovieService::m_movieService = nullptr;
+std::once_flag MovieService::instanceFlag;
+static const std::map<QString, int> audioChannelMap = {
+    { "mono",           1}, { "stereo",         2},
+    { "2.1",            3}, { "3.0",            3},
+    { "3.0(back)",      3}, { "4.0",            4},
+    { "quad",           4}, { "quad(side)",     4},
+    { "3.1",            4}, { "5.0",            5},
+    { "5.0(side)",      5}, { "4.1",            5},
+    { "5.1",            6}, { "5.1(side)",      6},
+    { "6.0",            6}, { "6.0(front)",     6},
+    { "hexagonal",      6}, { "6.1",            7},
+    { "6.1(back)",      7}, { "6.1(front)",     7},
+    { "7.0",            7}, { "7.0(front)",     7},
+    { "7.1",            8}, { "7.1(wide)",      8},
+    { "7.1(wide-side)", 8}, { "octagonal",      8},
+    { "hexadecagonal", 16}, { "downmix",        2},
+    { "22.2",          24}
+};
+
+MovieService *MovieService::instance(QObject *parent)
+{
+    Q_UNUSED(parent)
+    //线程安全单例
+    std::call_once(instanceFlag, [&]() {
+        m_movieService = new MovieService;
+        initGstreamerVideoThumbnailer();
+    });
+    return m_movieService;
+}
+
+MovieService::MovieService(QObject *parent)
+    : QObject(parent)
+{
+    //检查ffmpeg是否存在
+    if(checkCommandExist("ffmpeg")) {
+        resolutionPattern = "[0-9]+x[0-9]+";
+        codeRatePattern = "[0-9]+\\skb/s";
+        fpsPattern = "[0-9]+\\sfps";
+        m_ffmpegExist = true;
+    }
+
+    //检查ffmpegthumbnailer是否存在
+    if(checkCommandExist("ffmpegthumbnailer")) {
+        m_ffmpegthumbnailerExist = true;
+    }
+}
+
+bool MovieService::checkCommandExist(const QString &command)
+{
+    try {
+        QProcess bash;
+        bash.start("bash");
+        bash.waitForStarted();
+        bash.write(("command -v " + command).toUtf8());
+        bash.closeWriteChannel();
+        if (!bash.waitForFinished()) {
+            qWarning() << bash.errorString();
+            return false;
+        }
+        auto output = bash.readAllStandardOutput();
+        if (output.isEmpty()) {
+            return false;
+        } else {
+            return true;
+        }
+    } catch (std::logic_error &e) {
+        qWarning() << e.what();
+        return false;
+    }
+}
+
+MovieInfo MovieService::getMovieInfo(const QUrl &url)
+{
+    MovieInfo result;
+
+    m_bufferMutex.lock();
+    auto iter = std::find_if(m_movieInfoBuffer.begin(), m_movieInfoBuffer.end(), [url](const std::pair<QUrl, MovieInfo> &data) {
+        return data.first == url;
+    });
+    if (iter != m_movieInfoBuffer.end()) {
+        m_bufferMutex.unlock();
+        return iter->second;
+    }
+    m_bufferMutex.unlock();
+
+    if (url.isLocalFile()) {
+        QFileInfo fi(url.toLocalFile());
+        if (fi.exists() && fi.permission(QFile::Permission::ReadOwner)) { //存在且有读权限才能导入
+            if (!m_ffmpegExist) { //ffmpeg不存在，只读取基本信息
+                result.valid = true;
+                result.filePath = fi.absoluteFilePath();
+                result.fileSize = fi.size();
+                result.fileType = fi.suffix().toLower();
+                result.duration = "-";
+            } else { //ffmpeg存在，执行标准流程
+                auto filePath = fi.filePath();
+                result = parseFromFile(fi);
+            }
+        }
+    }
+
+    m_bufferMutex.lock();
+    m_movieInfoBuffer.push_back(std::make_pair(url, result));
+    if (m_movieInfoBuffer.size() > 30) {
+        m_movieInfoBuffer.pop_front();
+    }
+    m_bufferMutex.unlock();
+
+    return result;
+}
+
+static QString removeBrackets(const QString &str)
+{
+    QString result;
+    if (str.isEmpty()) {
+        return result;
+    }
+
+    std::vector<std::pair<int, int>> indexes;
+    std::deque<int> stackIndex;
+
+    for (int i = 0; i != str.size(); ++i) {
+        if (str[i] == '(') {
+            stackIndex.push_back(i);
+        } else if (str[i] == ')') {
+            if (stackIndex.size() == 1) {
+                indexes.push_back({stackIndex[0], i});
+            }
+            stackIndex.pop_back();
+        } else {
+            continue;
+        }
+    }
+
+    result = str;
+    for (int i = static_cast<int>(indexes.size() - 1); i >= 0; --i) {
+        auto data = indexes[static_cast<size_t>(i)];
+        result = result.remove(data.first, data.second - data.first + 1);
+    }
+
+    return result;
+}
+
+static QString searchLineFromKeyString(const std::string &key, const QString &targetStr)
+{
+    //视频流数据
+    QTextStream dataStream(targetStr.toUtf8(), QIODevice::ReadOnly);
+    QString infoString;
+
+    //搜索
+    while (1) {
+        auto currentLine = dataStream.readLine();
+        if (currentLine.isEmpty()) {
+            break;
+        }
+
+        auto index = currentLine.toStdString().find(key);
+        if (index != std::string::npos) {
+            infoString = currentLine.right(currentLine.size() - static_cast<int>(index + key.size()));
+            infoString = removeBrackets(infoString);
+            break;
+        }
+    }
+
+    return infoString;
+}
+
+MovieInfo MovieService::parseFromFile(const QFileInfo &fi)
+{
+    auto info = getMovieInfo_mediainfo(fi);
+    if(!info.valid) {
+        info = getMovieInfo_ffmpeg(fi);
+    }
+
+    return info;
+}
+
+QImage MovieService::getMovieCover(const QUrl &url, const QString &savePath)
+{
+    auto image = getMovieCover_gstreamer(url);
+    if(image.isNull()) {
+        image = getMovieCover_ffmpegthumbnailer(url, savePath);
+    }
+    return image;
+}
+
+QImage MovieService::getMovieCover_ffmpegthumbnailer(const QUrl &url, const QString &bufferPath)
+{
+    QImage image;
+    if (!m_ffmpegthumbnailerExist) {
+        return image;
+    }
+
+    QString path = url.toLocalFile();
+    QFileInfo info(path);
+
+    //QString savePath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + QDir::separator() + info.fileName() + ".png");
+    QString savePath(bufferPath + info.fileName() + ".png");
+
+    QByteArray output;
+    try {
+        QProcess ffmpegthumbnailer;
+        QStringList cmds{"-i", path, "-o", savePath};
+        ffmpegthumbnailer.start("ffmpegthumbnailer", cmds, QIODevice::ReadOnly);
+        if (!ffmpegthumbnailer.waitForFinished()) {
+            qWarning() << ffmpegthumbnailer.errorString();
+            return image;
+        }
+    } catch (std::logic_error &e) {
+        qWarning() << e.what();
+        return image;
+    }
+
+    image = QImage(savePath);
+
+    QFile::remove(savePath);
+
+    return image;
+}
+
+QImage MovieService::getMovieCover_gstreamer(const QUrl &url)
+{
+    return runGstreamerVideoThumbnailer(url);
+}
+
+MovieInfo MovieService::getMovieInfo_ffmpeg(const QFileInfo &fi)
+{
+    struct MovieInfo mi;
+
+    //使用命令行读取ffmpeg的输出
+    auto filePath = fi.absoluteFilePath();
+    QByteArray output;
+    try {
+        QProcess ffmpeg;
+        QStringList cmds{"-i", filePath, "-hide_banner"};
+        ffmpeg.start("ffmpeg", cmds, QIODevice::ReadOnly);
+        if (!ffmpeg.waitForFinished()) {
+            qWarning() << ffmpeg.errorString();
+            return mi;
+        }
+        output = ffmpeg.readAllStandardError(); //ffmpeg的视频基础信息是打在标准错误里面的，读标准输出是读不到东西的
+    } catch (std::logic_error &e) {
+        qWarning() << e.what();
+        return mi;
+    }
+
+    //至此视频信息已保存在output中
+
+    //1.错误输入
+    QString ffmpegOut = QString::fromUtf8(output);
+    if (ffmpegOut.endsWith("Invalid data found when processing input\n") ||
+            ffmpegOut.endsWith("Permission denied\n")) {
+        return mi;
+    }
+
+    //2.解析数据
+    mi.valid = true;
+
+    //2.1.文件信息
+    mi.filePath = filePath;
+    mi.fileType = fi.suffix().toLower();
+    mi.fileSize = fi.size();
+
+    //2.2.视频流数据
+    auto videoInfoString = searchLineFromKeyString("Video: ", ffmpegOut);
+    if (!videoInfoString.isEmpty()) {
+        auto videoStreamInfo = videoInfoString.split(", ");
+
+        //编码格式
+        mi.vCodecID = videoStreamInfo[0].split(" ")[0];
+
+        //分辨率，长宽比
+        QRegExp resolutionExp(resolutionPattern);
+        if (resolutionExp.indexIn(videoInfoString) > 0) {
+            mi.resolution = resolutionExp.cap(0);
+
+            auto videoSize = mi.resolution.split("x");
+            int size_w = videoSize[0].toInt();
+            int size_h = videoSize[1].toInt();
+            mi.proportion = static_cast<double>(size_w) / size_h;
+        } else {
+            mi.resolution = "-";
+            mi.proportion = -1;
+        }
+
+        //码率
+        QRegExp codeRateExp(codeRatePattern);
+        if (codeRateExp.indexIn(videoInfoString) > 0) {
+            auto codeRate = codeRateExp.cap(0);
+            mi.vCodeRate = codeRate.split(" ")[0].toInt();
+        } else {
+            mi.vCodeRate = 0;
+        }
+
+        //帧率
+        QRegExp fpsExp(fpsPattern);
+        if (fpsExp.indexIn(videoInfoString) > 0) {
+            auto fps = fpsExp.cap(0);
+            mi.fps = fps.split(" ")[0].toInt();
+        } else {
+            mi.fps = 0;
+        }
+    } else {
+        mi.vCodecID = "-";
+        mi.resolution = "-";
+        mi.proportion = -1;
+        mi.vCodeRate = 0;
+        mi.fps = 0;
+    }
+
+    //2.3.时长数据
+    auto timeInfoString = searchLineFromKeyString("Duration: ", ffmpegOut);
+    if (!timeInfoString.isEmpty()) {
+        mi.duration = timeInfoString.split(", ")[0].split(".")[0];
+        if (mi.duration == "N/A") {
+            mi.duration = "-";
+        }
+    }
+
+    //2.4.音频数据
+    auto audioInfoString = searchLineFromKeyString("Audio: ", ffmpegOut);
+    if (!audioInfoString.isEmpty()) {
+        auto audioStreamInfo = audioInfoString.split(", ");
+        mi.aCodeID = audioStreamInfo[0].split(" ")[0];
+        mi.sampling = audioStreamInfo[1].split(" ")[0].toInt();
+        mi.channels = audioChannelMap.at(audioStreamInfo[2]);
+        mi.aDigit = audioStreamInfo[3];
+
+        if (audioStreamInfo.size() > 4) {
+            mi.aCodeRate = audioStreamInfo[4].split(" ")[0].toInt();
+        } else {
+            mi.aCodeRate = 0;
+        }
+    } else {
+        mi.aCodeID = "-";
+        mi.sampling = 0;
+        mi.channels = 0;
+        mi.aDigit = "-";
+        mi.aCodeRate = 0;
+    }
+
+    //返回最终解析结果
+    return mi;
+}
+
+std::vector<std::pair<QString, QString>> searchGroupFromKey(const QString &key, const QStringList &datas)
+{
+    std::vector<std::pair<QString, QString>> result;
+
+    int i = 0;
+
+    //搜索起始位置
+    for(;i != datas.size();++i) {
+        if(datas[i] == key) {
+            ++i;
+            break;
+        }
+    }
+
+    //读取数据
+    for(;i != datas.size();++i) {
+        if(datas[i].isEmpty()) {
+            break;
+        }
+
+        auto tokens = datas[i].split(",");
+        if(tokens.size() < 2) { //数据异常
+            continue;
+        }
+        result.push_back(std::make_pair(tokens[0], tokens[1]));
+    }
+
+    return result;
+}
+
+MovieInfo MovieService::getMovieInfo_mediainfo(const QFileInfo &fi)
+{
+    struct MovieInfo mi;
+
+    MediaInfoDLL::MediaInfo info;
+    info.Open(fi.absoluteFilePath().toStdString());
+    info.Option("Complete", "1"); //解析全部数据
+    info.Option("Inform", "CSV"); //CSV格式输出
+    QString strData(info.Inform().c_str());
+
+    //至此视频信息已保存在infoList中，每条数据以key开头，以冒号分隔
+    QStringList infoList = strData.split("\n");
+
+    //2.解析数据
+    mi.valid = true;
+
+    //2.1.文件信息
+    mi.filePath = fi.absoluteFilePath();
+    mi.fileType = fi.suffix().toLower();
+    mi.fileSize = fi.size();
+
+    //2.2.视频流数据
+    auto videoGroup = searchGroupFromKey("Video", infoList);
+
+    //编码格式
+    for(auto &eachPair : videoGroup) {
+        if(eachPair.first == "Internet media type") {
+            auto str = eachPair.second;
+            auto list = str.split("/");
+            if(list.size() == 2) {
+                mi.vCodecID = list[1].toLower();
+            } else {
+                mi.vCodecID = str.toLower();
+            }
+            break;
+        }
+    }
+
+    //分辨率，长宽比
+    int width = 0;
+    int height = 0;
+    for(auto &eachPair : videoGroup) {
+        if(eachPair.first == "Width") {
+            width = eachPair.second.toInt();
+            if(width > 0) {
+                break;
+            }
+        }
+    }
+
+    for(auto &eachPair : videoGroup) {
+        if(eachPair.first == "Height") {
+            height = eachPair.second.toInt();
+            if(height > 0) {
+                break;
+            }
+        }
+    }
+
+    if(width > 0 && height > 0) {
+        mi.resolution = QString::number(width) + "x" + QString::number(height);
+        mi.proportion = static_cast<double>(width) / height;
+    }
+
+    //码率
+    for(auto &eachPair : videoGroup) {
+        if(eachPair.first == "Bit rate") {
+            auto codeRate = eachPair.second.toInt();
+            if(codeRate > 0) {
+                mi.vCodeRate = codeRate / 1000;
+                break;
+            }
+        }
+    }
+
+    //帧率
+    for(auto &eachPair : videoGroup) {
+        if(eachPair.first == "Frame rate") {
+            double fps = eachPair.second.toDouble();
+            if(fps > 0) {
+                mi.fps = static_cast<int>(fps);
+                break;
+            }
+        }
+    }
+
+    //2.3.时长数据
+    for(auto &eachPair : videoGroup) {
+        if(eachPair.first == "Duration") {
+            auto list = eachPair.second.split(".");
+            if(list.size() == 2) {
+                mi.duration = list[0];
+                break;
+            }
+        }
+    }
+
+    //2.4.音频数据
+    auto audioGroup = searchGroupFromKey("Audio", infoList);
+
+    //编码格式
+    for(auto &eachPair : audioGroup) {
+        if(eachPair.first == "Commercial name") {
+            mi.aCodeID = eachPair.second.toLower();
+            break;
+        }
+    }
+
+    //采样率
+    for(auto &eachPair : audioGroup) {
+        if(eachPair.first == "Sampling rate") {
+            int sampling = eachPair.second.toInt();
+            if(sampling > 0) {
+                mi.sampling = sampling;
+                break;
+            }
+        }
+    }
+
+    //通道数
+    for(auto &eachPair : audioGroup) {
+        if(eachPair.first == "Channel(s)") {
+            int channels = eachPair.second.toInt();
+            if(channels > 0) {
+                mi.channels = channels;
+                break;
+            }
+        }
+    }
+
+    //码率
+    for(auto &eachPair : audioGroup) {
+        if(eachPair.first == "Bit rate") {
+            int codeRate = eachPair.second.toInt();
+            if(codeRate > 0) {
+                mi.aCodeRate = codeRate / 1000;
+                break;
+            }
+        }
+    }
+
+    //音频位数（无法读出，待移除）
+    if(mi.aCodeID != "-") {
+        mi.aDigit = "8 bits";
+    }
+
+    //返回最终解析结果
+    return mi;
+}

--- a/libimageviewer/movieservice.h
+++ b/libimageviewer/movieservice.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     ZhangYong <zhangyong@uniontech.com>
+ *
+ * Maintainer: ZhangYong <ZhangYong@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef MOVIESERVICE_H
+#define MOVIESERVICE_H
+
+#include <QObject>
+#include <QMap>
+#include <QUrl>
+#include <QFileInfo>
+#include <QMutex>
+#include <QDateTime>
+#include <deque>
+#include <QStandardPaths>
+#include <mutex>
+#include <QDir>
+
+#include "image-viewer_global.h"
+
+struct MovieInfo {
+    bool valid = false;
+    QString filePath = "-";  //文件路径
+    QString fileType = "-";  //文件类型
+    QString resolution = "-";//分辨率
+    QDateTime creation;      //创建时间
+    qint64 fileSize = 0;     //文件大小
+    QString duration = "-";  //视频长度
+
+    //视频流信息
+    QString vCodecID = "-";  //编码格式
+    qint64 vCodeRate = 0;    //码率
+    int fps = 0;             //帧率
+    double proportion = -1;  //长宽比
+
+    //音频流信息
+    QString aCodeID = "-"; //编码格式
+    qint64 aCodeRate = 0;  //码率
+    QString aDigit = "-";  //数据格式
+    int channels = 0;      //通道数
+    int sampling = 0;      //采样率
+
+    QString sizeStr() const
+    {
+        auto K = 1024;
+        auto M = 1024 * K;
+        auto G = 1024 * M;
+        if (fileSize > G) {
+            return QString("%1G").arg((double)fileSize / G, 0, 'f', 1);
+        } else if (fileSize > M) {
+            return QString("%1M").arg((double)fileSize / M, 0, 'f', 1);
+        } else if (fileSize > K) {
+            return QString("%1K").arg((double)fileSize / K, 0, 'f', 1);
+        }
+        return QString("%1").arg(fileSize);
+    }
+};
+
+class IMAGEVIEWERSHARED_EXPORT MovieService: public QObject
+{
+    Q_OBJECT
+public:
+    static MovieService *instance(QObject *parent = nullptr);
+
+    //获取视频信息
+    MovieInfo getMovieInfo(const QUrl &url);
+
+    //获取视频首帧图片
+    QImage getMovieCover(const QUrl &url, const QString &savePath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + QDir::separator());
+
+private:
+    explicit MovieService(QObject *parent = nullptr);
+    struct MovieInfo parseFromFile(const QFileInfo &fi);
+
+private:
+    QImage getMovieCover_ffmpegthumbnailer(const QUrl &url, const QString &bufferPath);
+    QImage getMovieCover_gstreamer(const QUrl &url);
+
+    MovieInfo getMovieInfo_ffmpeg(const QFileInfo &fi);
+    MovieInfo getMovieInfo_mediainfo(const QFileInfo &fi);
+
+    bool checkCommandExist(const QString &command);
+
+    QMutex m_queuqMutex;
+    static MovieService *m_movieService;
+    static std::once_flag instanceFlag;
+    bool m_ffmpegExist = false;
+    bool m_ffmpegthumbnailerExist = false;
+    QMutex m_bufferMutex;
+    std::deque<std::pair<QUrl, MovieInfo>> m_movieInfoBuffer;
+
+    //ffmpeg用
+    QString resolutionPattern;
+    QString codeRatePattern;
+    QString fpsPattern;
+};
+
+#endif // MOVIESERVICE_H

--- a/libimageviewer/service/gstreamervideothumbnailer.cpp
+++ b/libimageviewer/service/gstreamervideothumbnailer.cpp
@@ -1,0 +1,476 @@
+/*
+ * Copyright (C) 2020 ~ 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     WangZhengYang <wangzhengyang@uniontech.com>
+ *
+ * Maintainer: HouChengQiu <houchengqiu@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <glib/gstdio.h>
+#include <glib/gi18n.h>
+#include <gst/gst.h>
+
+#include <string.h>
+#include <math.h>
+#include <stdlib.h>
+
+#include <QUrl>
+#include <QImage>
+
+//参考自totem项目
+
+struct ThumbApp {
+	GstElement *play;
+    gint64 duration;
+};
+
+enum FrameType {
+    RAW,
+    GL
+};
+
+static bool capsAreRaw(const GstCaps * caps)
+{
+    unsigned int len = gst_caps_get_size(caps);
+    for (unsigned int i = 0; i < len; i++) {
+        GstStructure *st = gst_caps_get_structure(caps, i);
+        if (gst_structure_has_name(st, "video/x-raw"))
+            return true;
+    }
+    return false;
+}
+
+static bool createElement(const gchar *factoryName, GstElement **element)
+{
+    *element = gst_element_factory_make (factoryName, nullptr);
+    return *element != nullptr;
+}
+
+static GstElement *buildPipeline(FrameType captureType, GstElement **srcElement, GstElement **sinkElement,
+                                 const GstCaps *fromCaps, const GstCaps *to_caps, GError **err)
+{
+    if (!capsAreRaw(to_caps)) {
+        return nullptr;
+    }
+
+    GstElement *csp = nullptr;
+    GstElement *vscale = nullptr;
+    GstElement *src = nullptr;
+    GstElement *sink = nullptr;
+    GstElement *dl = nullptr;
+    bool noElements = false;
+    do {
+        if (!createElement("appsrc", &src) ||
+                !createElement("appsink", &sink)) {
+            noElements = true;
+            break;
+        }
+
+        if (captureType == RAW) {
+            if (!createElement("videoconvert", &csp) ||
+                    !createElement("videoscale", &vscale)) {
+                noElements = true;
+                break;
+            }
+        } else {
+            if (!createElement("glcolorconvert", &csp) ||
+                    !createElement("glcolorscale", &vscale) ||
+                    !createElement("gldownload", &dl)) {
+                noElements = true;
+                break;
+            }
+        }
+    }while(0);
+
+    if(noElements) {
+        if (src) {
+            gst_object_unref(src);
+        }
+
+        if (csp) {
+            gst_object_unref(csp);
+        }
+
+        if (vscale) {
+            gst_object_unref(vscale);
+        }
+
+        if (dl) {
+            gst_object_unref(dl);
+        }
+
+        if (sink) {
+            gst_object_unref(sink);
+        }
+        return nullptr;
+    }
+
+    GstElement *pipeline = gst_pipeline_new ("videoconvert-pipeline");
+    if (pipeline == nullptr) {
+        gst_object_unref(src);
+        gst_object_unref(csp);
+        gst_object_unref(vscale);
+        g_clear_pointer(&dl, gst_object_unref);
+        gst_object_unref(sink);
+        if (err) {
+            *err = g_error_new(GST_CORE_ERROR, GST_CORE_ERROR_FAILED, "Could not convert video frame: no pipeline (unknown error)");
+        }
+        return nullptr;
+    }
+
+    if (g_object_class_find_property(G_OBJECT_GET_CLASS (vscale), "add-borders")) {
+        g_object_set(vscale, "add-borders", TRUE, nullptr);
+    }
+
+    gst_bin_add_many(GST_BIN (pipeline), src, csp, vscale, sink, dl, nullptr);
+    g_object_set(src, "caps", fromCaps, nullptr);
+    g_object_set(sink, "caps", to_caps, nullptr);
+
+    bool ret;
+    if (dl) {
+        ret = gst_element_link_many(src, csp, vscale, dl, sink, nullptr);
+    } else {
+        ret = gst_element_link_many(src, csp, vscale, sink, nullptr);
+    }
+
+    if (!ret) {
+        gst_object_unref(pipeline);
+        if (err) {
+            *err = g_error_new(GST_CORE_ERROR, GST_CORE_ERROR_NEGOTIATION, "Could not convert video frame: failed to link elements");
+        }
+        return nullptr;
+    }
+
+    g_object_set(src, "emit-signals", TRUE, nullptr);
+    g_object_set(sink, "emit-signals", TRUE, nullptr);
+    *srcElement = src;
+    *sinkElement = sink;
+    return pipeline;
+}
+
+static GstSample *getVideoSample(FrameType captureType, GstSample *sample,
+                                  const GstCaps *toCaps, GstClockTime timeout, GError **error)
+{
+    if(sample == nullptr || toCaps == nullptr) {
+        return nullptr;
+    }
+
+    GstBuffer *buf = gst_sample_get_buffer(sample);
+    if(buf == nullptr) {
+        return nullptr;
+    }
+
+    GstCaps *fromCaps = gst_sample_get_caps(sample);
+    if(fromCaps == nullptr) {
+        return nullptr;
+    }
+
+    GstCaps *toCapsCopy = gst_caps_new_empty();
+    size_t n = gst_caps_get_size(toCaps);
+    for (unsigned int i = 0; i < n; i++) {
+        GstStructure *s = gst_caps_get_structure(toCaps, i);
+
+        s = gst_structure_copy (s);
+        gst_structure_remove_field (s, "framerate");
+        gst_caps_append_structure (toCapsCopy, s);
+    }
+
+    GError *err = nullptr;
+    GstElement *sink;
+    GstElement *src;
+    GstElement *pipeline = buildPipeline(captureType, &src, &sink, fromCaps, toCapsCopy, &err);
+    if (!pipeline || gst_element_set_state(pipeline, GST_STATE_PAUSED) == GST_STATE_CHANGE_FAILURE) {
+        gst_caps_unref (toCapsCopy);
+        if (error) {
+            *error = err;
+        } else {
+            g_error_free (err);
+        }
+        return nullptr;
+    }
+
+    GstFlowReturn ret;
+    g_signal_emit_by_name (src, "push-buffer", buf, &ret);
+
+    GstBus *bus = gst_element_get_bus (pipeline);
+    GstMessage *msg = gst_bus_timed_pop_filtered (bus, timeout, static_cast<GstMessageType>(GST_MESSAGE_ERROR | GST_MESSAGE_ASYNC_DONE));
+
+    GstSample *result = nullptr;
+    if (msg) {
+        switch (GST_MESSAGE_TYPE(msg)) {
+        case GST_MESSAGE_ASYNC_DONE: {
+            g_signal_emit_by_name (sink, "pull-preroll", &result);
+            break;
+        }
+        case GST_MESSAGE_ERROR: {
+            gchar *dbg = nullptr;
+
+            gst_message_parse_error (msg, &err, &dbg);
+            if (err) {
+                if (error) {
+                    *error = err;
+                } else {
+                    g_error_free (err);
+                }
+            }
+            g_free (dbg);
+            break;
+        }
+        default:
+            g_return_val_if_reached(nullptr);
+        }
+        gst_message_unref (msg);
+    } else {
+        if (error) {
+            *error = g_error_new (GST_CORE_ERROR, GST_CORE_ERROR_FAILED,
+                                  "Could not convert video frame: timeout during conversion");
+        }
+    }
+
+    gst_element_set_state (pipeline, GST_STATE_NULL);
+    gst_object_unref (bus);
+    gst_object_unref (pipeline);
+    gst_caps_unref (toCapsCopy);
+
+    return result;
+}
+
+static QImage getImageFromPlayer(GstElement *play, GError **error)
+{
+    QImage result;
+
+    FrameType captureType = gst_bin_get_by_name(GST_BIN (play), "glcolorbalance0") ? GL : RAW;
+
+    GstCaps *toCaps = gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING,
+                                           captureType == RAW ? "RGB" : "RGBA",
+                                           "pixel-aspect-ratio", GST_TYPE_FRACTION, 1, 1, nullptr);
+
+    GstSample *lastSample = nullptr;
+    g_object_get(G_OBJECT (play), "sample", &lastSample, nullptr);
+    if (!lastSample) {
+        return result;
+    }
+    GstSample *sample = getVideoSample(captureType, lastSample, toCaps, 25 * GST_SECOND, error);
+    gst_sample_unref(lastSample);
+    gst_caps_unref(toCaps);
+
+    if (!sample) {
+        return result;
+    }
+
+    GstCaps *sampleCaps = gst_sample_get_caps(sample);
+    if (!sampleCaps) {
+        return result;
+    }
+
+    GstStructure *s = gst_caps_get_structure(sampleCaps, 0);
+    int outwidth = 0;
+    int outheight = 0;
+    gst_structure_get_int(s, "width", &outwidth);
+    gst_structure_get_int(s, "height", &outheight);
+    if (outwidth > 0 && outheight > 0) {
+        GstMemory *memory = gst_buffer_get_memory(gst_sample_get_buffer (sample), 0);
+        GstMapInfo info;
+        gst_memory_map(memory, &info, GST_MAP_READ);
+
+        result = QImage(info.data, outwidth, outheight, QImage::Format_RGB888);
+        gst_memory_unmap(memory, &info);
+        gst_memory_unref(memory);
+    }
+
+    if (result.isNull()) {
+        gst_sample_unref(sample);
+    }
+
+    int rotation = 0;
+    if (g_object_get_data(G_OBJECT (play), "orientation-checked") == nullptr) {
+        GstTagList *tags = nullptr;
+
+        g_signal_emit_by_name(G_OBJECT (play), "get-video-tags", 0, &tags);
+        if (tags) {
+            char *orientation_str;
+            bool ret = gst_tag_list_get_string_index(tags, GST_TAG_IMAGE_ORIENTATION, 0, &orientation_str);
+            if (!ret || !orientation_str) {
+                rotation = 0;
+            } else if (g_str_equal(orientation_str, "rotate-90")) {
+                rotation = 90;
+            } else if (g_str_equal(orientation_str, "rotate-180")) {
+                rotation = 180;
+            } else if (g_str_equal(orientation_str, "rotate-270")) {
+                rotation = 270;
+            }
+            gst_tag_list_unref (tags);
+        }
+
+        g_object_set_data(G_OBJECT (play), "orientation-checked", GINT_TO_POINTER(1));
+        g_object_set_data(G_OBJECT (play), "orientation", GINT_TO_POINTER(rotation));
+    }
+
+    QMatrix rotateMatrix;
+    rotateMatrix.rotate(rotation);
+    result = result.transformed(rotateMatrix, Qt::SmoothTransformation);
+
+    return result;
+}
+
+static bool startApp(ThumbApp *app)
+{
+	gst_element_set_state (app->play, GST_STATE_PAUSED);
+    GstBus *bus = gst_element_get_bus (app->play);
+    GstMessageType events = static_cast<GstMessageType>(GST_MESSAGE_ASYNC_DONE | GST_MESSAGE_ERROR);
+    bool needStop = false;
+    bool asyncHaveReceived = false;
+    while(!needStop) {
+        GstMessage *message = gst_bus_timed_pop_filtered (bus, GST_CLOCK_TIME_NONE, events); //主要耗时点
+        GstElement *src = (GstElement*)GST_MESSAGE_SRC (message);
+		switch (GST_MESSAGE_TYPE (message)) {
+		case GST_MESSAGE_ASYNC_DONE:
+			if (src == app->play) {
+                asyncHaveReceived = true;
+                needStop = true;
+			}
+			break;
+        case GST_MESSAGE_ERROR:
+            needStop = true;
+			break;
+		default:
+            break;
+		}
+        gst_message_unref (message);
+	}
+    gst_object_unref (bus);
+    return asyncHaveReceived;
+}
+
+static void buildSink(ThumbApp *app)
+{
+    //设置视频播放器
+    GstElement *play = gst_element_factory_make ("playbin", "play");
+
+    //设置视频数据管道
+    GstElement *videoSink = gst_element_factory_make ("fakesink", "video-fake-sink");
+    g_object_set(videoSink, "sync", true, nullptr);
+
+    //关闭视频前台播放
+    g_object_set(play, "video-sink", videoSink, "flags", 1, nullptr);
+
+    app->play = play;
+}
+
+static bool testImage(const QImage &image)
+{
+    //算法原理：通过统计整个图片像素点的方差来确认图片的鲜艳程度，方差越大图片整体色彩越鲜艳，也就越适合做缩略图
+
+    //1.提取像素点
+    const uchar* buffer = image.bits();
+    int pixelCount = image.bytesPerLine() * image.height();
+    float meanValue = 0.0f;
+    float variance = 0.0f;
+
+    //2.计算均值
+    for (int i = 0; i < pixelCount; i++) {
+        meanValue += static_cast<float>(buffer[i]);
+    }
+    meanValue /= static_cast<float>(pixelCount);
+
+    //3.计算方差
+    for (int i = 0; i < pixelCount; i++) {
+        float tmp = static_cast<float>(buffer[i]) - meanValue;
+        variance += tmp * tmp;
+    }
+    variance /= static_cast<float>(pixelCount - 1);
+
+    //4.当方差大于设定的阈值时，即表示该图片适合做缩略图
+    return variance > 256.0f;
+}
+
+static QImage getImage(ThumbApp *app)
+{
+    //图片截取流程
+
+    //1.如果无法读取视频的长度，则直接取第一帧作为结果
+    if (app->duration == -1) {
+        return getImageFromPlayer(app->play, nullptr);
+	}
+
+    //2.设置备选点位
+    const double pos[] = { 0.1, 1.0 / 3.0, 0.5, 2.0 / 3.0, 0.9 };
+    QImage image;
+
+    //3.点位筛选循环
+    for (int i = 0; i < G_N_ELEMENTS(pos); i++) {
+        //3.1跳转至目标点位
+        gst_element_seek (app->play, 1.0, GST_FORMAT_TIME, static_cast<GstSeekFlags>(GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_KEY_UNIT),
+                          GST_SEEK_TYPE_SET, pos[i] * app->duration * GST_MSECOND, GST_SEEK_TYPE_NONE, GST_CLOCK_TIME_NONE);
+        gst_element_get_state (app->play, nullptr, nullptr, GST_CLOCK_TIME_NONE);
+
+        //3.2执行截图
+        image = getImageFromPlayer(app->play, nullptr);
+
+        //3.3如果截图成功且截图满足要求
+        if (!image.isNull() && testImage(image)) {
+			break;
+        }
+	}
+
+    //4.返回图片
+    return image;
+}
+
+QImage runGstreamerVideoThumbnailer(const QUrl &videoUrl)
+{
+    QImage result;
+
+    //读取输入视频路径和输出图像路径
+    //视频路径需要用URL格式，图像路径需要用一般绝对路径格式
+    ThumbApp app;
+
+    //建立管道
+    buildSink(&app);
+
+    //对播放器设置输入文件名
+    g_object_set(app.play, "uri", videoUrl.url().toStdString().c_str(), nullptr);
+
+    //打开视频文件（主要耗时点）
+    //此处会自动分析是否是有效的视频文件
+    if (startApp(&app) == false) {
+        return result;
+    }
+
+    //读取并设置视频时长
+    gint64 len = -1;
+    if (gst_element_query_duration (app.play, GST_FORMAT_TIME, &len) && len != -1) {
+        app.duration = len / GST_MSECOND;
+    } else {
+        app.duration = -1;
+    }
+
+    //抓取图片
+    result = getImage(&app);
+
+    //释放播放器资源
+    gst_element_set_state(app.play, GST_STATE_NULL);
+    g_clear_object(&app.play);
+
+    return result;
+}
+
+void initGstreamerVideoThumbnailer()
+{
+    int argc = 0;
+    char **argv = {};
+    gst_init(&argc, &argv);
+}

--- a/libimageviewer/service/gstreamervideothumbnailer.h
+++ b/libimageviewer/service/gstreamervideothumbnailer.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 ~ 2022 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     WangZhengYang <wangzhengyang@uniontech.com>
+ *
+ * Maintainer: HouChengQiu <houchengqiu@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QImage>
+#include <QUrl>
+
+extern void initGstreamerVideoThumbnailer();
+extern QImage runGstreamerVideoThumbnailer(const QUrl &videoUrl);


### PR DESCRIPTION
1.添加mediainfo作为主要的视频基础数据解析库，ffmpeg命令行为备用库
2.添加gstreamer作为主要的视频缩略图解析库，ffmpegthumbnailer命令行为备用库

Log: 添加双引擎视频解析库以解决缩略图不一致和速度慢
Bug: https://pms.uniontech.com/bug-view-129569.html