### PR TITLE
fix: 修复【PGV】【相册】相册中选择图片点击导出后，鼠标光标在相册界面不可见的问题

### DIFF
--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -1619,8 +1619,9 @@ void LibViewPanel::onMenuItemClicked(QAction *action)
 
             PrintHelper::getIntance()->showPrintDialog(QStringList(m_bottomToolbar->getCurrentItemInfo().path), this);
 
-            //开启定时器
-            m_hideCursorTid = startTimer(DELAY_HIDE_CURSOR_INTERVAL);
+            // 全屏时，开启定时器，3秒后隐藏鼠标
+            if (window()->isFullScreen())
+                m_hideCursorTid = startTimer(DELAY_HIDE_CURSOR_INTERVAL);
             break;
         }
         case IdRename: {


### PR DESCRIPTION
Description: 仅在全屏时，关闭打印窗口后，开启定时器，三秒后隐藏鼠标

Log: 修复【PGV】【相册】相册中选择图片点击导出后，鼠标光标在相册界面不可见的问题

Bug: https://pms.uniontech.com/bug-view-147995.html