### PR TITLE
fix: 解决模态窗口显示下，全屏图片不能显示鼠标的问题

### DIFF
--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -2051,7 +2051,8 @@ void LibViewPanel::dropEvent(QDropEvent *event)
 void LibViewPanel::timerEvent(QTimerEvent *e)
 {
     if (e->timerId() == m_hideCursorTid && (!m_menu || !m_menu->isVisible())) {
-        m_view->viewport()->setCursor(Qt::BlankCursor);
+        if (!QApplication::activeModalWidget())
+            m_view->viewport()->setCursor(Qt::BlankCursor);
     }
 
     QFrame::timerEvent(e);


### PR DESCRIPTION
Description: 若为模态窗口，不隐藏鼠标

Log: 解决模态窗口显示下，全屏图片不能显示鼠标的问题

Bug: https://pms.uniontech.com/bug-view-147995.html