### PR TITLE
fix: use correct LIBDIR for pkgconfig

### DIFF
--- a/libimageviewer/libimageviewer.pc.in
+++ b/libimageviewer/libimageviewer.pc.in
@@ -1,12 +1,12 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}/bin
 libimageviewer=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include/libimageviewer
 
 Name: image-viewer
 Description: deepin image viewer plugins
 Version: @PROJECT_VERSION@
-Libs: -limageviewer
+Libs: -L${libimageviewer} -limageviewer
 Cflags: -I${includedir}
-Requires: Qt5Core Qt5Gui Qt5Widgets QtSvg Qt5DBus Qt5Concurrent Qt5PrintSupport Qt5LinguistTools dtkcore dtkwidget freeimage
+Requires: Qt5Core Qt5Gui Qt5Widgets Qt5Svg Qt5DBus Qt5Concurrent Qt5PrintSupport dtkcore dtkwidget
 

--- a/libimagevisualresult/libimagevisualresult.pc.in
+++ b/libimagevisualresult/libimagevisualresult.pc.in
@@ -1,11 +1,11 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}/bin
 libimagevisualresult=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include/libimagevisualresult
 
 Name: imagevisualresult
 Description: deepin image viewer plugins
 Version: @PROJECT_VERSION@
-Libs: -limagevisualresult
+Libs: -L${libimageviewer} -limagevisualresult
 Cflags: -I${includedir}
 


### PR DESCRIPTION
1. 完善文件路径
2. 补充 -L 参数
3. QtSvg -> Qt5Svg
4. 删除pkgconfig对 Qt5LinguistTools  freeimage 的检查

https://bugzilla.redhat.com/show_bug.cgi?id=1471417
https://sourceforge.net/p/freeimage/feature-requests/57/

Qt5LinguistTools  freeimage 的上游应该没有提供 .pc 文件
