### PR TITLE
feat: 完善 cmakelist.txt 

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -29,7 +29,7 @@ Copyright: UnionTech Software Technology Co., Ltd.
 License: CC0-1.0
 
 # Project file
-Files: *.pro *.prf *.pri *.qrc *CMakeLists.txt .tx/* 
+Files: *.pro *.prf *.pri *.qrc *CMakeLists.txt .tx/* cmake/*
 Copyright: UnionTech Software Technology Co., Ltd.
 License: CC0-1.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.0.0)
 
 project(imageeditor)
+set (VERSION "1.0.20" CACHE STRING "define project version")
 
 execute_process(COMMAND uname -m OUTPUT_VARIABLE MACH
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/cmake/Findfreeimage.cmake
+++ b/cmake/Findfreeimage.cmake
@@ -1,0 +1,56 @@
+#
+# Try to find the FreeImage library and include path.
+# Once done this will define
+#
+# freeimage_FOUND
+# freeimage_INCLUDE_PATH
+# freeimage_LIBRARY
+#
+
+find_path(freeimage_INCLUDE_DIR
+  NAMES FreeImage.h
+  PATHS
+  /usr/include
+  /usr/local/include
+  /sw/include
+  /opt/local/include
+  ${CMAKE_INCLUDE_PATH}
+  ${CMAKE_INSTALL_PREFIX}/include)
+
+find_library(freeimage_LIBRARY
+  NAMES FreeImage freeimage
+  PATHS
+  /usr/lib64
+  /usr/lib
+  /usr/local/lib64
+  /usr/local/lib
+  /sw/lib
+  /opt/local/lib
+  ${CMAKE_LIBRARY_PATH}
+  ${CMAKE_INSTALL_PREFIX}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(freeimage
+  FOUND_VAR freeimage_FOUND
+  REQUIRED_VARS
+    freeimage_LIBRARY
+    freeimage_INCLUDE_DIR
+)
+
+if(freeimage_FOUND)
+  set(freeimage_LIBRARIES ${freeimage_LIBRARY})
+  set(freeimage_INCLUDE_DIRS ${freeimage_INCLUDE_DIR})
+endif()
+
+if(freeimage_FOUND AND NOT TARGET freeimage::FreeImage)
+  add_library(freeimage::FreeImage UNKNOWN IMPORTED)
+  set_target_properties(freeimage::FreeImage PROPERTIES
+    IMPORTED_LOCATION "${freeimage_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${freeimage_INCLUDE_DIR}"
+  )
+endif()
+
+mark_as_advanced(
+  freeimage_INCLUDE_DIR
+  freeimage_LIBRARY
+)

--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,7 @@
 include /usr/share/dpkg/default.mk
 export QT_SELECT=5
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+PACK_VER = $(shell echo $(DEB_VERSION_UPSTREAM) | awk -F'[+_~-]' '{print $$1}')
 
 %:
 	dh $@
@@ -10,5 +11,5 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 	  -DCMAKE_BUILD_TYPE=Release \
 	  -DCMAKE_INSTALL_PREFIX=/usr \
-      -DAPP_VERSION=$(DEB_VERSION_UPSTREAM) -DVERSION=$(DEB_VERSION_UPSTREAM) LIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH)
+      -DAPP_VERSION=$(PACK_VER) -DVERSION=$(PACK_VER) LIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH)
 

--- a/libimageviewer/CMakeLists.txt
+++ b/libimageviewer/CMakeLists.txt
@@ -15,14 +15,25 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-#Qt需要的包
-set(QtModule Core Gui Widgets Svg DBus Concurrent PrintSupport LinguistTools)
-
 set(TARGET_NAME imageviewer)
 set(CMD_NAME imageviewer)
 
+# include custom Modules
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
+#Qt需要的包
+set(QtModule Core Gui Widgets Svg DBus Concurrent PrintSupport LinguistTools)
 #先查找到这些qt相关的模块以供链接使用
 find_package(Qt5 REQUIRED ${QtModule})
+find_package(freeimage REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(3rd_lib REQUIRED
+    dtkwidget
+    dtkcore
+    dtkgui
+    gobject-2.0
+    libmediainfo
+    libffmpegthumbnailer
+    )
 
 #设置输出目录
 #set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/../deepin-album/lib)
@@ -39,14 +50,7 @@ add_definitions( -DCMAKE_BUILD )
 aux_source_directory(imageviewer allSources)
 
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(3rd_lib REQUIRED
-    dtkwidget
-    dtkcore
-    dtkgui
-    gobject-2.0
-    libmediainfo
-    )
+
 
 #需要打开的头文件
 FILE (GLOB allHeaders "*.h" "*/*.h" "*/*/*.h")
@@ -60,13 +64,6 @@ file(GLOB_RECURSE RESOURCES "*.qrc")
 
 #------------------添加第三方库begins--------------------------#
 #使用第三方库需要用到的一个包
-
-set(INC_DIR /usr/include/)
-set(LINK_DIR /usr/lib/)
-
-include_directories(${INC_DIR})
-link_directories(${LINK_DIR})
-
 link_libraries(freeimage)
 
 set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM 1)
@@ -101,8 +98,8 @@ set(${TARGET_NAME} ${CMAKE_INSTALL_LIBDIR})
 set_target_properties(${TARGET_NAME} PROPERTIES VERSION 0.1.0 SOVERSION 0.1)
 
 
-target_include_directories(${CMD_NAME} PUBLIC ${3rd_lib_INCLUDE_DIRS}  )
-target_link_libraries(imageviewer ${3rd_lib_LIBRARIES} freeimage )
+target_include_directories(${CMD_NAME} PUBLIC ${3rd_lib_INCLUDE_DIRS})
+target_link_libraries(imageviewer ${3rd_lib_LIBRARIES} freeimage::FreeImage)
 
 configure_file(libimageviewer.pc.in ${PROJECT_BINARY_DIR}/libimageviewer.pc @ONLY)
 

--- a/libimageviewer/CMakeLists.txt
+++ b/libimageviewer/CMakeLists.txt
@@ -50,8 +50,6 @@ add_definitions( -DCMAKE_BUILD )
 aux_source_directory(imageviewer allSources)
 
 
-
-
 #需要打开的头文件
 FILE (GLOB allHeaders "*.h" "*/*.h" "*/*/*.h")
 #需要打开的代码文件
@@ -95,7 +93,9 @@ endif ()
 
 set(${TARGET_NAME} ${CMAKE_INSTALL_LIBDIR})
 
-set_target_properties(${TARGET_NAME} PROPERTIES VERSION 0.1.0 SOVERSION 0.1)
+set_target_properties(${TARGET_NAME} PROPERTIES
+                    VERSION "${PROJECT_VERSION}"
+                    SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 
 
 target_include_directories(${CMD_NAME} PUBLIC ${3rd_lib_INCLUDE_DIRS})

--- a/libimageviewer/CMakeLists.txt
+++ b/libimageviewer/CMakeLists.txt
@@ -2,7 +2,12 @@
 cmake_minimum_required(VERSION 3.10)
 
 # 设置工程名字
-project(libimageviewer VERSION 0.1.0)
+project (libimageviewer
+  VERSION ${VERSION}
+  DESCRIPTION "libimageviewer is a public library for deepin-image-viewer and deepin-album"
+  HOMEPAGE_URL "https://github.com/linuxdeepin/image-editor"
+  LANGUAGES CXX C
+)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/libimageviewer/CMakeLists.txt
+++ b/libimageviewer/CMakeLists.txt
@@ -86,7 +86,11 @@ qt5_use_modules(imageviewer ${QtModule})
 
 
 #将库安装到指定位置
-set(PREFIX /usr)
+include(GNUInstallDirs)
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX /usr)
+endif ()
+
 set(${TARGET_NAME} ${CMAKE_INSTALL_LIBDIR})
 
 set_target_properties(${TARGET_NAME} PROPERTIES VERSION 0.1.0 SOVERSION 0.1)
@@ -95,7 +99,6 @@ set_target_properties(${TARGET_NAME} PROPERTIES VERSION 0.1.0 SOVERSION 0.1)
 target_include_directories(${CMD_NAME} PUBLIC ${3rd_lib_INCLUDE_DIRS}  )
 target_link_libraries(imageviewer ${3rd_lib_LIBRARIES} freeimage )
 
-include(GNUInstallDirs)
 configure_file(libimageviewer.pc.in ${PROJECT_BINARY_DIR}/libimageviewer.pc @ONLY)
 
 install(TARGETS ${CMD_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -105,12 +108,12 @@ install(FILES
     imageviewer.h
     image-viewer_global.h
     movieservice.h
-    DESTINATION include/libimageviewer)
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libimageviewer)
 
 install(FILES ${PROJECT_BINARY_DIR}/libimageviewer.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 #translations
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/translations
-    DESTINATION ${PREFIX}/share/libimageviewer
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/libimageviewer
     FILES_MATCHING PATTERN "*.qm")
 
 # 加速编译优化参数

--- a/libimageviewer/libimageviewer.pc.in
+++ b/libimageviewer/libimageviewer.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}/bin
-libimageviewer=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/include/libimageviewer
+exec_prefix=${prefix}
+libimageviewer=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/libimageviewer
 
 Name: image-viewer
 Description: deepin image viewer plugins
@@ -9,4 +9,3 @@ Version: @PROJECT_VERSION@
 Libs: -L${libimageviewer} -limageviewer
 Cflags: -I${includedir}
 Requires: Qt5Core Qt5Gui Qt5Widgets Qt5Svg Qt5DBus Qt5Concurrent Qt5PrintSupport dtkcore dtkwidget
-

--- a/libimagevisualresult/CMakeLists.txt
+++ b/libimagevisualresult/CMakeLists.txt
@@ -59,7 +59,9 @@ endif ()
 
 set(${TARGET_NAME} ${CMAKE_INSTALL_LIBDIR})
 
-set_target_properties(${TARGET_NAME} PROPERTIES VERSION 0.1.0 SOVERSION 0.1)
+set_target_properties(${TARGET_NAME} PROPERTIES
+                    VERSION "${PROJECT_VERSION}"
+                    SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 
 configure_file(libimagevisualresult.pc.in  ${PROJECT_BINARY_DIR}/libimagevisualresult.pc @ONLY)
 

--- a/libimagevisualresult/CMakeLists.txt
+++ b/libimagevisualresult/CMakeLists.txt
@@ -53,27 +53,30 @@ set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM 1)
 add_library(${TARGET_NAME} SHARED ${SRCS} ${allHeaders} ${allSource})
 
 #将库安装到指定位置
-set(PREFIX /usr)
+include(GNUInstallDirs)
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX /usr)
+endif ()
+
 set(${TARGET_NAME} ${CMAKE_INSTALL_LIBDIR})
 
 set_target_properties(${TARGET_NAME} PROPERTIES VERSION 0.1.0 SOVERSION 0.1)
 
-include(GNUInstallDirs)
 configure_file(libimagevisualresult.pc.in  ${PROJECT_BINARY_DIR}/libimagevisualresult.pc @ONLY)
 
 install(TARGETS ${TARGET_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-install(FILES ${OUT_HEADERS} DESTINATION include/libimagevisualresult)
+install(FILES ${OUT_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libimagevisualresult)
 
 install(FILES ${PROJECT_BINARY_DIR}/libimagevisualresult.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 # CUBE 颜色表文件 安装到usr/share下， 方便其他应用访问
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/filter_cube
-    DESTINATION ${PREFIX}/share/libimagevisualresult
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/libimagevisualresult
     FILES_MATCHING PATTERN "*.CUBE")
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/filter_cube
-    DESTINATION ${PREFIX}/share/libimagevisualresult
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/libimagevisualresult
     FILES_MATCHING PATTERN "*.dat")
 
 # 加速编译优化参数

--- a/libimagevisualresult/CMakeLists.txt
+++ b/libimagevisualresult/CMakeLists.txt
@@ -2,7 +2,12 @@
 cmake_minimum_required(VERSION 3.10)
 
 # 设置工程名称
-project(libimagevisualresult VERSION 0.1.0)
+project (libimagevisualresult
+  VERSION ${VERSION}
+  DESCRIPTION "libimagevisualresult is a public library for deepin-image-viewer and deepin-album"
+  HOMEPAGE_URL "https://github.com/linuxdeepin/image-editor"
+  LANGUAGES CXX C
+)
 
 set(TARGET_NAME imagevisualresult)
 

--- a/libimagevisualresult/CMakeLists.txt
+++ b/libimagevisualresult/CMakeLists.txt
@@ -16,8 +16,8 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
-find_package(PkgConfig REQUIRED)
 find_package(OpenCV REQUIRED)
+find_package(PkgConfig REQUIRED)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -37,12 +37,6 @@ set(SRCS
 file (GLOB_RECURSE OUT_HEADERS ${CMAKE_CURRENT_LIST_DIR}/src/visualresult.h)
 
 #-------------添加第三方库begins-----------------------#
-set(INC_DIR /usr/include/)
-set(LINK_DIR /usr/lib/)
-
-include_directories(${INC_DIR})
-link_directories(${LINK_DIR})
-
 add_executable(${PROJECT_NAME} ${SRCS})
 
 # 设置不删除生成的文件夹内容文件

--- a/libimagevisualresult/libimagevisualresult.pc.in
+++ b/libimagevisualresult/libimagevisualresult.pc.in
@@ -1,11 +1,10 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}/bin
-libimagevisualresult=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/include/libimagevisualresult
+exec_prefix=${prefix}
+libimagevisualresult=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/libimagevisualresult
 
 Name: imagevisualresult
 Description: deepin image viewer plugins
 Version: @PROJECT_VERSION@
-Libs: -L${libimageviewer} -limagevisualresult
+Libs: -L${libimagevisualresult} -limagevisualresult
 Cflags: -I${includedir}
-


### PR DESCRIPTION
1. 使用 GNUInstallDirs 模块提供的变量代替硬编码路径
2. 修复 libimagevisualresult.pc.in 错误的 -L 参数
3. pkg_check_modules 检查增加 libffmpegthumbnailer
4. 编写 cmake 模块用于引入 freeimage
5. 设置正确的版本号