### PR TITLE
fix: 照顾一下文管的.so搜索机制

### DIFF
--- a/debian/libimageeditor-dev.install
+++ b/debian/libimageeditor-dev.install
@@ -1,5 +1,4 @@
 usr/include/libimageviewer/*.h
-usr/lib/*/libimageviewer.so
 usr/lib/*/pkgconfig/libimageviewer.pc
 usr/include/libimagevisualresult/*.h
 usr/lib/*/libimagevisualresult.so

--- a/debian/libimageeditor.install
+++ b/debian/libimageeditor.install
@@ -1,4 +1,5 @@
 usr/lib/*/libimageviewer.so.*
+usr/lib/*/libimageviewer.so
 usr/share/libimageviewer/translations/*.qm
 usr/lib/*/libimagevisualresult.so.*
 usr/share/libimagevisualresult/filter_cube/*.CUBE


### PR DESCRIPTION
文管组拒绝使用自动搜索.so的代码，此处将在安装主包的时候将不带版本号的.so安装进去

Log: 照顾一下文管的.so搜索机制