### PR TITLE
fix: 修改动图显示为平滑缩放模式

### DIFF
--- a/libimageviewer/viewpanel/scen/graphicsitem.cpp
+++ b/libimageviewer/viewpanel/scen/graphicsitem.cpp
@@ -11,6 +11,9 @@ LibGraphicsMovieItem::LibGraphicsMovieItem(const QString &fileName, const QStrin
     : QGraphicsPixmapItem(fileName, parent)
 {
     Q_UNUSED(suffix);
+
+    setTransformationMode(Qt::SmoothTransformation);
+
     m_movie = new QMovie(fileName);
     QObject::connect(m_movie, &QMovie::frameChanged, this, [ = ] {
         if (m_movie.isNull()) return;


### PR DESCRIPTION
在快速缩放下，部分动图会出现奇怪的显示结果
目前修改为和静态图保持一致，使用平滑缩放进行显示

Log: 修改动图显示为平滑缩放模式
Bug: https://pms.uniontech.com/bug-view-154885.html