### PR TITLE
fix: 修复未安装deepin-ocr时，相关按钮仍然显示出来

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-image-editor (1.0.19) unstable; urgency=medium
+image-editor (1.0.22) unstable; urgency=medium
 
   * Add movie information interface
 

--- a/libimageviewer/movieservice.cpp
+++ b/libimageviewer/movieservice.cpp
@@ -12,6 +12,7 @@
 #include <QtDebug>
 #include <QJsonDocument>
 #include "service/gstreamervideothumbnailer.h"
+#include "unionimage/baseutils.h"
 
 #ifdef EnableFFmpegLib
 #include "service/ffmpegvideothumbnailer.h"
@@ -56,7 +57,7 @@ MovieService::MovieService(QObject *parent)
     : QObject(parent)
 {
     //检查ffmpeg是否存在
-    if (checkCommandExist("ffmpeg")) {
+    if (Libutils::base::checkCommandExist("ffmpeg")) {
         resolutionPattern = "[0-9]+x[0-9]+";
         codeRatePattern = "[0-9]+\\skb/s";
         fpsPattern = "[0-9]+\\sfps";
@@ -64,7 +65,7 @@ MovieService::MovieService(QObject *parent)
     }
 
     //检查ffmpegthumbnailer是否存在
-    if (checkCommandExist("ffmpegthumbnailer")) {
+    if (Libutils::base::checkCommandExist("ffmpegthumbnailer")) {
         m_ffmpegthumbnailerExist = true;
     }
 
@@ -74,30 +75,6 @@ MovieService::MovieService(QObject *parent)
         m_ffmpegThumLibExist = true;
     }
 #endif
-}
-
-bool MovieService::checkCommandExist(const QString &command)
-{
-    try {
-        QProcess bash;
-        bash.start("bash");
-        bash.waitForStarted();
-        bash.write(("command -v " + command).toUtf8());
-        bash.closeWriteChannel();
-        if (!bash.waitForFinished()) {
-            qWarning() << bash.errorString();
-            return false;
-        }
-        auto output = bash.readAllStandardOutput();
-        if (output.isEmpty()) {
-            return false;
-        } else {
-            return true;
-        }
-    } catch (std::logic_error &e) {
-        qWarning() << e.what();
-        return false;
-    }
 }
 
 MovieInfo MovieService::getMovieInfo(const QUrl &url)

--- a/libimageviewer/movieservice.h
+++ b/libimageviewer/movieservice.h
@@ -87,7 +87,6 @@ private:
     MovieInfo getMovieInfo_ffmpeg(const QFileInfo &fi);
     MovieInfo getMovieInfo_mediainfo(const QFileInfo &fi);
 
-    bool checkCommandExist(const QString &command);
     bool isCrashFormat(const QUrl &url);
 
     QMutex m_queuqMutex;

--- a/libimageviewer/unionimage/baseutils.cpp
+++ b/libimageviewer/unionimage/baseutils.cpp
@@ -457,20 +457,31 @@ bool mountDeviceExist(const QString &path)
 
     return QFileInfo(mountPoint).exists();
 }
-//bool        isCommandExist(const QString &command)
-//{
-//    QProcess *proc = new QProcess;
-//    QString cm = QString("which %1\n").arg(command);
-//    proc->start(cm);
-//    proc->waitForFinished(1000);
 
-//    if (proc->exitCode() == 0) {
-//        return true;
-//    } else {
-//        return false;
-//    }
+bool checkCommandExist(const QString &command)
+{
+    try {
+        QProcess bash;
+        bash.start("bash");
+        bash.waitForStarted();
+        bash.write(("command -v " + command).toUtf8());
+        bash.closeWriteChannel();
+        if (!bash.waitForFinished()) {
+            qWarning() << bash.errorString();
+            return false;
+        }
+        auto output = bash.readAllStandardOutput();
+        if (output.isEmpty()) {
+            return false;
+        } else {
+            return true;
+        }
+    } catch (std::logic_error &e) {
+        qWarning() << e.what();
+        return false;
+    }
+}
 
-//}
 }  // namespace base
 
 }  // namespace utils

--- a/libimageviewer/unionimage/baseutils.h
+++ b/libimageviewer/unionimage/baseutils.h
@@ -144,6 +144,7 @@ bool        trashFile(const QString &file);
 
 bool        onMountDevice(const QString &path);
 bool        mountDeviceExist(const QString &path);
+bool checkCommandExist(const QString &command);
 //bool        isCommandExist(const QString &command);
 }  // namespace base
 

--- a/libimageviewer/viewpanel/contents/bottomtoolbar.cpp
+++ b/libimageviewer/viewpanel/contents/bottomtoolbar.cpp
@@ -61,12 +61,8 @@ const int LOAD_LEFT_RIGHT = 25;     //前后加载图片数（动态）
 
 LibBottomToolbar::LibBottomToolbar(QWidget *parent) : DFloatingWidget(parent)
 {
+    //m_ocrIsExists = Libutils::base::checkCommandExist("deepin-ocr");
     this->setBlurBackgroundEnabled(true);
-//    this->blurBackground()->setRadius(30);
-//    this->blurBackground()->setBlurEnabled(true);
-//    this->blurBackground()->setMode(DBlurEffectWidget::GaussianBlur);
-//    QColor backMaskColor(255, 255, 255, 140);
-//    this->blurBackground()->setMaskColor(backMaskColor);
     initUI();
     initConnection();
     QObject::connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,
@@ -127,7 +123,7 @@ int LibBottomToolbar::getToolbarWidth()
     if (m_rotateLBtn->isVisible()) {
         width += m_rotateLBtn->width() + ICON_SPACING;//左旋
     }
-    if (m_ocrBtn->isVisible()) {
+    if (m_ocrIsExists && m_ocrBtn->isVisible()) {
         width += m_ocrBtn->width() + ICON_SPACING;//OCR
     }
     if (m_rotateRBtn->isVisible()) {
@@ -176,7 +172,7 @@ void LibBottomToolbar::setRotateBtnClicked(const bool &bRet)
 
 void LibBottomToolbar::setPictureDoBtnClicked(const bool &bRet)
 {
-    if (m_ocrBtn) {
+    if (m_ocrIsExists && m_ocrBtn) {
         m_ocrBtn->setEnabled(bRet);
     }
     if (m_adaptImageBtn) {
@@ -218,7 +214,9 @@ DIconButton *LibBottomToolbar::getBottomtoolbarButton(imageViewerSpace::ButtonTy
         button = m_clBT;
         break;
     case imageViewerSpace::ButtonTypeOcr:
-        button = m_ocrBtn;
+        if (m_ocrIsExists) {
+            button = m_ocrBtn;
+        }
         break;
     case imageViewerSpace::ButtonTypeRotateLeft:
         button = m_rotateLBtn;
@@ -408,7 +406,11 @@ void LibBottomToolbar::slotThemeChanged(int type)
         DApplicationHelper::instance()->setPalette(m_adaptImageBtn, pa);
         DApplicationHelper::instance()->setPalette(m_adaptScreenBtn, pa);
         DApplicationHelper::instance()->setPalette(m_clBT, pa);
-        DApplicationHelper::instance()->setPalette(m_ocrBtn, pa);
+
+        if (m_ocrIsExists) {
+            DApplicationHelper::instance()->setPalette(m_ocrBtn, pa);
+        }
+
         DApplicationHelper::instance()->setPalette(m_rotateLBtn, pa);
         DApplicationHelper::instance()->setPalette(m_rotateRBtn, pa);
         DApplicationHelper::instance()->setPalette(m_trashBtn, pa);
@@ -433,7 +435,11 @@ void LibBottomToolbar::slotThemeChanged(int type)
         DApplicationHelper::instance()->setPalette(m_adaptImageBtn, pa);
         DApplicationHelper::instance()->setPalette(m_adaptScreenBtn, pa);
         DApplicationHelper::instance()->setPalette(m_clBT, pa);
-        DApplicationHelper::instance()->setPalette(m_ocrBtn, pa);
+
+        if (m_ocrIsExists) {
+            DApplicationHelper::instance()->setPalette(m_ocrBtn, pa);
+        }
+
         DApplicationHelper::instance()->setPalette(m_rotateLBtn, pa);
         DApplicationHelper::instance()->setPalette(m_rotateRBtn, pa);
         DApplicationHelper::instance()->setPalette(m_trashBtn, pa);
@@ -462,12 +468,18 @@ void LibBottomToolbar::slotOpenImage(int index, QString path)
         m_adaptImageBtn->setChecked(false);
         m_adaptScreenBtn->setEnabled(false);
         m_trashBtn->setEnabled(false);
-        m_ocrBtn->setEnabled(false);
+
+        if (m_ocrIsExists) {
+            m_ocrBtn->setEnabled(false);
+        }
     } else {
         m_adaptImageBtn->setEnabled(true);
         m_adaptScreenBtn->setEnabled(true);
         m_trashBtn->setEnabled(true);
-        m_ocrBtn->setEnabled(true);
+
+        if (m_ocrIsExists) {
+            m_ocrBtn->setEnabled(true);
+        }
     }
 }
 
@@ -494,7 +506,7 @@ void LibBottomToolbar::onNextButton()
     if (m_rotateRBtn) {
         m_rotateRBtn->setEnabled(false);
     }
-    if (m_ocrBtn) {
+    if (m_ocrIsExists && m_ocrBtn) {
         m_ocrBtn->setEnabled(false);
     }
     if (m_imgListWidget) {
@@ -511,7 +523,7 @@ void LibBottomToolbar::onPreButton()
     if (m_rotateRBtn) {
         m_rotateRBtn->setEnabled(false);
     }
-    if (m_ocrBtn) {
+    if (m_ocrIsExists && m_ocrBtn) {
         m_ocrBtn->setEnabled(false);
     }
     if (m_imgListWidget) {
@@ -712,12 +724,14 @@ void LibBottomToolbar::initUI()
     hb->addWidget(m_clBT);
 
     //ocr
-    m_ocrBtn = new DIconButton(this);
-    m_ocrBtn->setFixedSize(ICON_SIZE);
-    m_ocrBtn->setIcon(QIcon::fromTheme("dcc_ocr"));
-    m_ocrBtn->setIconSize(QSize(36, 36));
-    m_ocrBtn->setToolTip(QObject::tr("Extract text"));
-    hb->addWidget(m_ocrBtn);
+    if (m_ocrIsExists) {
+        m_ocrBtn = new DIconButton(this);
+        m_ocrBtn->setFixedSize(ICON_SIZE);
+        m_ocrBtn->setIcon(QIcon::fromTheme("dcc_ocr"));
+        m_ocrBtn->setIconSize(QSize(36, 36));
+        m_ocrBtn->setToolTip(QObject::tr("Extract text"));
+        hb->addWidget(m_ocrBtn);
+    }
 
     //向左旋转
     m_rotateLBtn = new DIconButton(this);
@@ -788,7 +802,9 @@ void LibBottomToolbar::initConnection()
     //删除
     connect(m_trashBtn, &DIconButton::clicked, this, &LibBottomToolbar::onTrashBtnClicked);
     //ocr
-    connect(m_ocrBtn, &DIconButton::clicked, this, &LibBottomToolbar::sigOcr);
+    if (m_ocrIsExists) {
+        connect(m_ocrBtn, &DIconButton::clicked, this, &LibBottomToolbar::sigOcr);
+    }
 }
 
 void LibBottomToolbar::setButtonAlawysNotVisible(imageViewerSpace::ButtonType id, bool notVisible)

--- a/libimageviewer/viewpanel/contents/bottomtoolbar.h
+++ b/libimageviewer/viewpanel/contents/bottomtoolbar.h
@@ -177,6 +177,7 @@ private:
     bool badaptImageBtnChecked = false;
     bool badaptScreenBtnChecked = false;
     QString m_currentpath = "";
+    bool m_ocrIsExists = false;
 };
 
 #endif // BOTTOMTOOBAR_H

--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -480,11 +480,13 @@ void LibViewPanel::updateMenuContent(QString path)
 
         //ocr按钮,是否是动态图,todo
         DIconButton *OcrButton = m_bottomToolbar->getBottomtoolbarButton(imageViewerSpace::ButtonTypeOcr);
-        if (imageViewerSpace::ImageTypeDynamic != imageType && isPic && isReadable) {
-            appendAction(IdOcr, QObject::tr("Extract text"), ss("Extract text", "Alt+O"));
-            OcrButton->setEnabled(true);
-        } else {
-            OcrButton->setEnabled(false);
+        if (OcrButton != nullptr) {
+            if (imageViewerSpace::ImageTypeDynamic != imageType && isPic && isReadable) {
+                appendAction(IdOcr, QObject::tr("Extract text"), ss("Extract text", "Alt+O"));
+                OcrButton->setEnabled(true);
+            } else {
+                OcrButton->setEnabled(false);
+            }
         }
 
         //如果图片数量大于0才能有幻灯片


### PR DESCRIPTION
原因是未对deepin-ocr的安装情况作判断
解决方法是检测deepin-ocr命令是否可用，当不可用时即判定为未安装deepin-ocr，或相关功能损坏，此时即隐藏按钮

Log: 修复未安装deepin-ocr时，相关按钮仍然显示出来
Bug: https://pms.uniontech.com/bug-view-159241.html