### PR TITLE
fix: 修复图片信息偶现没有拍摄日期等信息

### DIFF
--- a/libimageviewer/unionimage/unionimage.cpp
+++ b/libimageviewer/unionimage/unionimage.cpp
@@ -336,10 +336,11 @@ UNIONIMAGESHARED_EXPORT QMap<QString, QString> getMetaData(FREE_IMAGE_MDMODEL mo
             do {
                 QString value;
                 // FreeImage_TagToString非线程安全，使用前加锁保护
-                if (g_freeImageTagToStringMutex.exists()) {
-                    g_freeImageTagToStringMutex->lock();
+                QMutex *mutex = g_freeImageTagToStringMutex;
+                if (mutex) {
+                    mutex->lock();
                     value = QString(FreeImage_TagToString(model, tag));
-                    g_freeImageTagToStringMutex->unlock();
+                    mutex->unlock();
                 }
 
                 mdMap.insert(FreeImage_GetTagKey(tag), value);


### PR DESCRIPTION
Description: 使用Q_GLOBAL_STATIC宏的方式存在错误，未构造单例对象，exists()持续返回false，未正常读取图片数据。修改使用方式，保证多线程安全下，构造单实例对象。

Log: 修复图片信息偶现没有拍摄日期等信息
Bug: https://pms.uniontech.com/bug-view-185337.html
Influence: 获取图片元数据