### PR TITLE
fix: 修复切换图片查看时，图片信息刷新两次的问题

### DIFF
--- a/libimageviewer/viewpanel/contents/imageinfowidget.h
+++ b/libimageviewer/viewpanel/contents/imageinfowidget.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,32 +18,28 @@
 DWIDGET_USE_NAMESPACE
 typedef DLabel QLbtoDLabel;
 
-//class DBaseExpand;
 class QFormLayout;
 class QVBoxLayout;
 class ViewSeparator;
+
 class LibImageInfoWidget : public QFrame
 {
     Q_OBJECT
 public:
-    explicit LibImageInfoWidget(const QString &darkStyle,
-                                const QString &lightStyle,
-                                QWidget *parent = nullptr);
+    explicit LibImageInfoWidget(const QString &darkStyle, const QString &lightStyle, QWidget *parent = nullptr);
     ~LibImageInfoWidget() Q_DECL_OVERRIDE;
-    void setImagePath(const QString path);
+    void setImagePath(const QString &path, bool forceUpdate = true);
     void updateInfo();
     int contentHeight() const;
-//    QSize sizeHint() const override;
 
 signals:
     void extensionPanelHeight(int height);
-public slots:
-//    void onExpandChanged(const bool &e);
 
 protected:
     void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
     void timerEvent(QTimerEvent *e) Q_DECL_OVERRIDE;
     void paintEvent(QPaintEvent *event) Q_DECL_OVERRIDE;
+
 private:
     void clearLayout(QLayout *layout);
     const QString trLabel(const char *str);
@@ -54,12 +50,13 @@ private:
 
 private:
     int m_updateTid = 0;
-    int m_maxTitleWidth;  //For align colon
+    int m_maxTitleWidth;  // For align colon
     int m_maxFieldWidth;
-    int m_currentFontSize; //LMH0609上次显示的字体大小
+    int m_currentFontSize;  // LMH0609上次显示的字体大小
     bool m_isBaseInfo = false;
     bool m_isDetailsInfo = false;
     QString m_path;
+    QMap<QString, QString> m_metaData;
     QFrame *m_exif_base = nullptr;
     QFrame *m_exif_details = nullptr;
     QFormLayout *m_exifLayout_base = nullptr;
@@ -71,4 +68,4 @@ private:
     QString m_closedString;
 };
 
-#endif // IMAGEINFOWIDGET_H
+#endif  // IMAGEINFOWIDGET_H

--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -378,7 +378,7 @@ void LibViewPanel::initExtensionPanel()
     }
 }
 
-void LibViewPanel::updateMenuContent(QString path)
+void LibViewPanel::updateMenuContent(const QString &path)
 {
     //判断是否为相册调用
     bool isAlbum = false;
@@ -424,33 +424,8 @@ void LibViewPanel::updateMenuContent(QString path)
         setCurrentWidget(currentPath);
 
         if (m_info) {
-            m_info->setImagePath(currentPath);
+            m_info->setImagePath(currentPath, false);
         }
-//        if (!isFile && !currentPath.isEmpty()) {
-//            if (m_thumbnailWidget) {
-//                m_stack->setCurrentWidget(m_thumbnailWidget);
-//                //损坏图片不透明
-//                emit m_view->sigImageOutTitleBar(false);
-//                m_thumbnailWidget->setThumbnailImage(QPixmap::fromImage(ItemInfo.image));
-//            }
-//        } else if (isPic) {
-//            m_stack->setCurrentWidget(m_view);
-//            //判断下是否透明
-//            m_view->titleBarControl();
-//        } else if (!currentPath.isEmpty() && ItemInfo.pathType == pathType && ItemInfo.imageType == imageType) {
-//            if (m_lockWidget) {
-//                m_stack->setCurrentWidget(m_lockWidget);
-//                //损坏图片不透明
-//                emit m_view->sigImageOutTitleBar(false);
-//            }
-//        }
-
-        //如果是图片，按钮恢复，否则按钮置灰
-//        if (isPic) {
-//            m_bottomToolbar->setPictureDoBtnClicked(true);
-//        } else {
-//            m_bottomToolbar->setPictureDoBtnClicked(false);
-//        }
 
         if (imageViewerSpace::ImageTypeDamaged == imageType) {
             return;

--- a/libimageviewer/viewpanel/viewpanel.h
+++ b/libimageviewer/viewpanel/viewpanel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -65,7 +65,7 @@ public:
     //初始化快捷键
     void initShortcut();
     //更新右键菜单
-    void updateMenuContent(QString path = "");
+    void updateMenuContent(const QString &path = "");
     //控制全屏和返回全屏
     void toggleFullScreen();
     //全屏


### PR DESCRIPTION
Description: 原因是图片在切换和加载完成后触发了两次菜单刷新操作，
导致界面重复刷新。图片在切换和加载完成后所取得的详细信息是一致的。
修改为根据数据变更刷新详细信息，且保留强制刷新的功能。

Log: 修复切换图片查看时，图片信息刷新两次的问题
Bug: https://pms.uniontech.com/bug-view-175369.html
Influence: 图片信息