### PR TITLE
fix: 修复打印图片时无图片路径信息的问题

### DIFF
--- a/libimageviewer/widgets/printhelper.cpp
+++ b/libimageviewer/widgets/printhelper.cpp
@@ -129,11 +129,9 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
     || (DTK_VERSION_MAJOR >= 5 && DTK_VERSION_MINOR >= 4 && DTK_VERSION_PATCH >= 10))//5.4.4暂时没有合入
     //增加运行时版本判断
     if (DApplication::runtimeDtkVersion() >= DTK_VERSION_CHECK(5, 4, 10, 0)) {
-        if (tempExsitPaths.count() > 0) {
+        if (!tempExsitPaths.isEmpty()) {
             //直接传递为路径,不会有问题
-            QString docName = QString(QFileInfo(tempExsitPaths.at(0)).completeBaseName());
-            docName = docName + ".pdf";
-            printDialog2.setDocName(docName);
+            printDialog2.setDocName(QFileInfo(tempExsitPaths.at(0)).absoluteFilePath());
         }
     }
 #endif


### PR DESCRIPTION
图片打印时仅设置图片名，且后缀为pdf。
修改为完整路径，以便cups服务获取准确打印信息。

Log: 修复打印图片时无图片路径信息的问题
Bug: https://pms.uniontech.com/bug-view-188457.html
Influence: DTK5.4.10以上的图片打印