### PR TITLE
Fix build using gcc13: add missing include cstdint

### DIFF
--- a/libimagevisualresult/src/utils.h
+++ b/libimagevisualresult/src/utils.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <map>
+#include <cstdint>
 #include <string>
 
 typedef std::vector<std::vector<uint8_t>>       lutData;


### PR DESCRIPTION
GCC 13 no longer includes cstdint in all cases and code is supposed to handle this

Fixes build fails like:
[   96s] In file included from /home/abuild/rpmbuild/BUILD/image-editor-1.0.19/libimagevisualresult/src/lut.cpp:22:
[   96s] /home/abuild/rpmbuild/BUILD/image-editor-1.0.19/libimagevisualresult/src/utils.h:8:33: error: 'uint8_t' was not declared in this scope
[   96s]     8 | typedef std::vector<std::vector<uint8_t>>       lutData;
[   96s]       |                                 ^~~~~~~
