### PR TITLE
fix: 修复相册-大图模式删除图片，没有显示删除确认弹窗的问题

### DIFF
--- a/libimageviewer/imageengine.h
+++ b/libimageviewer/imageengine.h
@@ -5,12 +5,13 @@
 #ifndef IMAGEENGINE_H
 #define IMAGEENGINE_H
 
+#define DELETE_CONFIRM
+
 #include "image-viewer_global.h"
 
 #include <DWidget>
 #include <QtCore/qglobal.h>
 #include <QImage>
-
 DWIDGET_USE_NAMESPACE
 
 class ImageEnginePrivate;
@@ -44,7 +45,11 @@ signals:
     //更新收藏按钮
     void sigUpdateCollectBtn();
     //删除
-    void sigDel(QString path);
+#ifdef DELETE_CONFIRM
+    void sigConfirmDel(const QString &path); // 通知相册，准备删除图片，并让相册弹出删除确认弹窗
+    void sigDeleteImage(); // 相册确认删除图片，通知看图执行删除图片后的业务逻辑
+#endif
+    void sigDel(QString path); // 通知相册，删除图片
     //获取自定义相册
     void sigGetAlbumName(const QString &path);
     //添加到已有相册/新建相册

--- a/libimageviewer/viewpanel/contents/bottomtoolbar.cpp
+++ b/libimageviewer/viewpanel/contents/bottomtoolbar.cpp
@@ -16,6 +16,7 @@
 #include <DImageButton>
 #include <DThumbnailProvider>
 #include <DApplicationHelper>
+#include <QMetaObject>
 #include <DSpinner>
 
 #include "imgviewlistview.h"
@@ -377,9 +378,13 @@ void LibBottomToolbar::onTrashBtnClicked()
     if (path.isEmpty() && m_currentpath.isEmpty()) {
         path = m_currentpath;
     }
+
+#ifdef DELETE_CONFIRM
+    emit ImageEngine::instance()->sigConfirmDel(path);
+#else
     deleteImage();
     emit ImageEngine::instance()->sigDel(path);
-    //    emit dApp->signalM->deleteByMenu();
+#endif
 }
 
 void LibBottomToolbar::slotThemeChanged(int type)
@@ -801,6 +806,9 @@ void LibBottomToolbar::initConnection()
     connect(m_imgListWidget, &MyImageListWidget::openImg, this, &LibBottomToolbar::slotOpenImage);
     //删除
     connect(m_trashBtn, &DIconButton::clicked, this, &LibBottomToolbar::onTrashBtnClicked);
+#ifdef DELETE_CONFIRM
+    connect(ImageEngine::instance(), &ImageEngine::sigDeleteImage, this, &LibBottomToolbar::deleteImage);
+#endif
     //ocr
     if (m_ocrIsExists) {
         connect(m_ocrBtn, &DIconButton::clicked, this, &LibBottomToolbar::sigOcr);


### PR DESCRIPTION
  添加显示删除确认弹窗的处理流程，同步修改相册代码

Log: 修复相册-大图模式删除图片，没有显示删除确认弹窗的问题
Bug: https://pms.uniontech.com/bug-view-157033.html