### PR TITLE
fix: 修复重名提示时，输入框未标红的问题

### DIFF
--- a/libimageviewer/widgets/renamedialog.cpp
+++ b/libimageviewer/widgets/renamedialog.cpp
@@ -188,6 +188,7 @@ void RenameDialog::setCurrentTip()
         m_lineedt->hideAlertMessage();
     } else if (file.exists()) {
         okbtn->setEnabled(false);
+        m_lineedt->setAlert(true);
         m_lineedt->showAlertMessage(tr("The file already exists, please use another name"), m_lineedt);
     } else if (m_lineedt->text().isEmpty()) {
         okbtn->setEnabled(false);


### PR DESCRIPTION
   修复重名提示时，输入框未标红的问题

Log: 修复重名提示时，输入框未标红的问题
Bug: https://pms.uniontech.com/bug-view-194689.html