### PR TITLE
fix: 修复打开看图闪退的问题

### DIFF
--- a/libimageviewer/unionimage/imageutils.cpp
+++ b/libimageviewer/unionimage/imageutils.cpp
@@ -783,7 +783,8 @@ bool imageSupportWallPaper(const QString &path)
     return mt.name().startsWith("image")
            && !mt.name().endsWith("svg+xml")
            && !mt.name().endsWith("raf")
-           && !mt.name().endsWith("crw");
+           && !mt.name().endsWith("crw")
+           && !mt.name().endsWith("x-portable-anymap");
 }
 
 //bool suffixisImage(const QString &path)

--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -589,7 +589,8 @@ void LibViewPanel::updateMenuContent(const QString &path)
         //需要判断图片是否支持设置壁纸，若不支持则置灰设置壁纸菜单项
         if (isPic) {
             QAction *ac = appendAction(IdSetAsWallpaper, QObject::tr("Set as wallpaper"), ss("Set as wallpaper", "Ctrl+F9"));
-            ac->setEnabled(Libutils::image::imageSupportWallPaper(ItemInfo.path));
+            if (ac)
+                ac->setEnabled(Libutils::image::imageSupportWallPaper(ItemInfo.path));
         }
         if (isReadable) {
             appendAction(IdDisplayInFileManager, QObject::tr("Display in file manager"),
@@ -695,7 +696,11 @@ QAction *LibViewPanel::appendAction(int id, const QString &text, const QString &
         ac->setProperty("MenuID", id);
         ac->setShortcut(QKeySequence(shortcut));
         m_menu->addAction(ac);
+
+        return ac;
     }
+
+    return nullptr;
 }
 
 void LibViewPanel::setContextMenuItemVisible(imageViewerSpace::NormalMenuItemId id, bool visible)


### PR DESCRIPTION
   用看图打开图片时，会判断是否置灰设为壁纸菜单项，需要对返回的设为壁纸菜单项做判空处理

Log: 修复打开看图闪退的问题