### PR TITLE
fix: 修复低版本相册点击大图-删除按钮无效的问题

### DIFF
--- a/libimageviewer/imageengine.h
+++ b/libimageviewer/imageengine.h
@@ -46,7 +46,6 @@ signals:
     void sigUpdateCollectBtn();
     //删除
 #ifdef DELETE_CONFIRM
-    void sigConfirmDel(const QString &path); // 通知相册，准备删除图片，并让相册弹出删除确认弹窗
     void sigDeleteImage(); // 相册确认删除图片，通知看图执行删除图片后的业务逻辑
 #endif
     void sigDel(QString path); // 通知相册，删除图片

--- a/libimageviewer/viewpanel/contents/bottomtoolbar.cpp
+++ b/libimageviewer/viewpanel/contents/bottomtoolbar.cpp
@@ -379,19 +379,21 @@ void LibBottomToolbar::onTrashBtnClicked()
         path = m_currentpath;
     }
 
+    if (LibCommonService::instance()->getImgViewerType() == imageViewerSpace::ImgViewerType::ImgViewerTypeAlbum) {
+        // 相册浏览图片-删除按钮逻辑处理
 #ifdef DELETE_CONFIRM
-    // 相册浏览大图-删除图片，才给出删除确认弹窗
-    if (LibCommonService::instance()->getImgViewerType() == imageViewerSpace::ImgViewerType::ImgViewerTypeAlbum)
-        emit ImageEngine::instance()->sigConfirmDel(path);
-    else {
+        // 新流程，相册会弹出删除确认提示框，点击确认，相册才给imageeditor发送sigDeleteImage信号删除图片
+        emit ImageEngine::instance()->sigDel(path);
+#else
+        // 老流程，直接删除
+        deleteImage();
+        emit ImageEngine::instance()->sigDel(path);
+#endif
+    } else {
         //本地图片浏览-删除图片，直接删除
         deleteImage();
         emit ImageEngine::instance()->sigDel(path);
     }
-#else
-    deleteImage();
-    emit ImageEngine::instance()->sigDel(path);
-#endif
 }
 
 void LibBottomToolbar::slotThemeChanged(int type)


### PR DESCRIPTION
  大图-删除按钮处理流程整理：
  1.看图-大图删除按钮：直接删除图片
  2.相册-大图删除按钮：
    a.老版本，直接删除图片，保持和看图逻辑一致
    b.新版本，弹出删除确认弹窗

 deepin-album相关pr:
 https://github.com/linuxdeepin/deepin-album/pull/155

Log: 修复低版本相册点击大图-删除按钮无效的问题