### PR TITLE
fix: 修复图片读取和保存图片的问题

### DIFF
--- a/libimageviewer/unionimage/unionimage.cpp
+++ b/libimageviewer/unionimage/unionimage.cpp
@@ -1086,10 +1086,10 @@ UNIONIMAGESHARED_EXPORT bool rotateImageFIle(int angel, const QString &path, QSt
             QMatrix rotatematrix;
             rotatematrix.rotate(angel);
             image_copy = image_copy.transformed(rotatematrix, Qt::SmoothTransformation);
-            if (image_copy.save(path, format.toLatin1().data(), SAVE_QUAITY_VALUE))
+
+            // 调整图片质量，不再默认使用满质量 SAVE_QUAITY_VALUE
+            if (image_copy.save(path, format.toLatin1().data(), -1)) {
                 return true;
-            else {
-                return false;
             }
         }
         erroMsg = "rotate by qt failed";

--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -1233,17 +1233,20 @@ bool LibViewPanel::startChooseFileDialog()
                 }
             }
         }
-        if (image_list.count() > 0) {
-            bRet = true;
-        } else {
-            bRet = false;
+
+        // Note: 即使传入文件路径，但文件可能被管控无法读取数据，列表为空。
+        if (image_list.isEmpty()) {
+            return false;
         }
+        bRet = true;
+
         QString loadingPath;
         if (image_list.contains(path)) {
             loadingPath = path;
         } else {
             loadingPath = image_list.first();
         }
+
         //stack设置正确位置
         m_stack->setCurrentWidget(m_view);
         //展示当前图片


### PR DESCRIPTION
1. 管控图片读取时,返回图片但文件不可读取,
二次确定图片类型时可读取列表为空,未进行边界判断,
添加列表边界判断处理.
2. 保存图片文件时默认按最高质量存储,调整为默认值,
以在保留质量的情况下降低磁盘使用率.