### PR TITLE
fix: Crash when not found libffmpegthumbnailer.so

### DIFF
--- a/libimageviewer/movieservice.cpp
+++ b/libimageviewer/movieservice.cpp
@@ -11,6 +11,7 @@
 #include <QProcess>
 #include <QtDebug>
 #include <QJsonDocument>
+#include <QTemporaryDir>
 #include "unionimage/baseutils.h"
 #include "service/ffmpegvideothumbnailer.h"
 
@@ -211,12 +212,16 @@ QImage MovieService::getMovieCover_ffmpegthumbnailer(const QUrl &url, const QStr
     }
 
     QString path = url.toLocalFile();
+    QString savePath;
     QFileInfo info(path);
+    QTemporaryDir tempDir;
+    // 此处临时文件创建后被删除，调整为使用tmp目录
+    if (tempDir.isValid()) {
+        savePath = tempDir.filePath(info.fileName() + ".png");
+    } else {
+        savePath = QString(bufferPath + info.fileName() + ".png");
+    }
 
-    //QString savePath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + QDir::separator() + info.fileName() + ".png");
-    QString savePath(bufferPath + info.fileName() + ".png");
-
-    QByteArray output;
     try {
         QProcess ffmpegthumbnailer;
         QStringList cmds{"-i", path, "-o", savePath};

--- a/libimageviewer/service/ffmpegvideothumbnailer.cpp
+++ b/libimageviewer/service/ffmpegvideothumbnailer.cpp
@@ -10,6 +10,7 @@
 #include <QLibrary>
 #include <QDir>
 #include <QLibraryInfo>
+#include <QDebug>
 
 #include <libffmpegthumbnailer/videothumbnailerc.h>
 
@@ -32,12 +33,19 @@ static bool resolveSuccessed = false;
 
 bool initFFmpegVideoThumbnailer()
 {
-    QLibrary library("libffmpegthumbnailer.so");
+    QLibrary library("libffmpegthumbnailer.so.4");
+
     m_creat_video_thumbnailer = reinterpret_cast<mvideo_thumbnailer_create>(library.resolve("video_thumbnailer_create"));
     m_mvideo_thumbnailer_destroy = reinterpret_cast<mvideo_thumbnailer_destroy>(library.resolve("video_thumbnailer_destroy"));
     m_mvideo_thumbnailer_create_image_data = reinterpret_cast<mvideo_thumbnailer_create_image_data>(library.resolve("video_thumbnailer_create_image_data"));
     m_mvideo_thumbnailer_destroy_image_data = reinterpret_cast<mvideo_thumbnailer_destroy_image_data>(library.resolve("video_thumbnailer_destroy_image_data"));
     m_mvideo_thumbnailer_generate_thumbnail_to_buffer = reinterpret_cast<mvideo_thumbnailer_generate_thumbnail_to_buffer>(library.resolve("video_thumbnailer_generate_thumbnail_to_buffer"));
+
+    if (nullptr == m_creat_video_thumbnailer) {
+        qWarning() << QString("Resolve libffmpegthumbnailer.so data failed, %1").arg(library.errorString());
+        resolveSuccessed = false;
+        return false;
+    }
     m_video_thumbnailer = m_creat_video_thumbnailer();
 
     if (m_mvideo_thumbnailer_destroy == nullptr


### PR DESCRIPTION
软件调整环境变量,可能未查找到库,解析接口时,
遗漏判空处理,导致访问越界;
同时调整创建临时图片的方式,改为 QTemporaryDir 的方式.

Log: 修复未查找到ffmpeg依赖包时崩溃的问题
Bug: https://pms.uniontech.com/bug-view-213565.html
Influence: MovieCover