### PR TITLE
chore: Bump version to 1.0.36

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+image-editor (1.0.36) unstable; urgency=medium
+
+  * fix: Crash when not found libffmpegthumbnailer.so (#93)
+    (Bug: 213565)(Influence: MovieCover)
+
+ -- Deepin Packages Builder <packages@deepin.org>  Tue, 26 Sep 2023 17:54:32 +0800
+
 image-editor (1.0.35) unstable; urgency=medium
 
   * feat: just use QLibrary to search .so


### PR DESCRIPTION
Bump version to 1.0.36
PR:
* https://github.com/linuxdeepin/image-editor/pull/93

Log: Bump version to 1.0.36