### PR TITLE
chore: [ Community ] Bump version to 1.0.37

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+image-editor (1.0.37) unstable; urgency=medium
+
+  * Bump version for community, previous is 1.0.34
+  * fix: Crash when not found libffmpegthumbnailer.so (#93)
+    (Bug: 213565)(Influence: MovieCover)
+
+ -- Deepin Packages Builder <packages@deepin.org>  Tue, 26 Sep 2023 17:56:57 +0800
+
 image-editor (1.0.36) unstable; urgency=medium
 
   * fix: Crash when not found libffmpegthumbnailer.so (#93)


### PR DESCRIPTION
Bump version to 1.0.37 for community,
previous is 1.0.34
PR:
* https://github.com/linuxdeepin/image-editor/pull/90
* https://github.com/linuxdeepin/image-editor/pull/92
* https://github.com/linuxdeepin/image-editor/pull/93

Log: [ Community ] Bump version to 1.0.37