### PR TITLE
fix: compact mode build faild on low dtkgui version.

### DIFF
--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -79,9 +79,8 @@ QString ss(const QString &text, const QString &defaultValue)
 int titleBarHeight()
 {
     // DTK 在 5.6.4 后提供紧凑模式接口，调整控件大小
-#if DTK_VERSION_CHECK(5, 6, 4, 0) <= DTK_VERSION_CHECK(DTK_VERSION_MAJOR, DTK_VERSION_MINOR, DTK_VERSION_PATCH, DTK_VERSION_BUILD)
-    int checkVersion = DTK_VERSION_CHECK(5, 6, 4, 0);
-    if (checkVersion <= dtkVersion() && DGuiApplicationHelper::isCompactMode()) {
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    if (DGuiApplicationHelper::isCompactMode()) {
         return COMPACT_TITLEBAR_HEIGHT;
     } else {
         return TITLEBAR_HEIGHT;
@@ -269,18 +268,15 @@ void LibViewPanel::initConnect()
     connect(m_dirWatcher, &QFileSystemWatcher::directoryChanged, this, &LibViewPanel::slotsDirectoryChanged);
 
     // DTK 在 5.6.4 后提供紧凑模式接口，调整控件大小
-#if DTK_VERSION_CHECK(5, 6, 4, 0) <= DTK_VERSION_CHECK(DTK_VERSION_MAJOR, DTK_VERSION_MINOR, DTK_VERSION_PATCH, DTK_VERSION_BUILD)
-    int checkVersion = DTK_VERSION_CHECK(5, 6, 4, 0);
-    if (checkVersion <= dtkVersion()) {
-        connect(DGuiApplicationHelper::instance(),
-                &DGuiApplicationHelper::sizeModeChanged,
-                this,
-                [this](DGuiApplicationHelper::SizeMode) {
-                    m_topToolbar->resize(width(), titleBarHeight());
-                    m_topToolbar->move(0, 0);
-                    m_topToolbar->update();
-                });
-    }
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    connect(DGuiApplicationHelper::instance(),
+            &DGuiApplicationHelper::sizeModeChanged,
+            this,
+            [this](DGuiApplicationHelper::SizeMode) {
+                m_topToolbar->resize(width(), titleBarHeight());
+                m_topToolbar->move(0, 0);
+                m_topToolbar->update();
+            });
 #endif
 }
 

--- a/libimageviewer/widgets/toptoolbar.cpp
+++ b/libimageviewer/widgets/toptoolbar.cpp
@@ -45,9 +45,8 @@ const int COMPACT_BURSH_TEXTURE_HEIGHT = 60;
 int paintBrushHeight()
 {
     // DTK 在 5.6.4 后提供紧凑模式接口，调整控件大小
-#if DTK_VERSION_CHECK(5, 6, 4, 0) <= DTK_VERSION_CHECK(DTK_VERSION_MAJOR, DTK_VERSION_MINOR, DTK_VERSION_PATCH, DTK_VERSION_BUILD)
-    int checkVersion = DTK_VERSION_CHECK(5, 6, 4, 0);
-    if (checkVersion <= dtkVersion() && DGuiApplicationHelper::isCompactMode()) {
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    if (DGuiApplicationHelper::isCompactMode()) {
         return COMPACT_BURSH_TEXTURE_HEIGHT;
     } else {
         return BRUSH_TEXTURE_HEIGHT;


### PR DESCRIPTION
旧版使用DTK版本号判断是否开启紧凑模式编译.
但在dtkcore高版本,dtkgui低版本的情况下,
会导致进入编译代码,但不存在紧凑模式接口,
编译失败.

Log: 修复在低版本dtkgui构建失败问题.
Influence: CompactMode
Change-Id: I94598866cbf305a9596b47d124991bee96ffd538