### PR TITLE
fix: Init type error / disable drag in processing.

### DIFF
--- a/libimageviewer/viewpanel/contents/imgviewlistview.cpp
+++ b/libimageviewer/viewpanel/contents/imgviewlistview.cpp
@@ -308,6 +308,13 @@ void LibImgViewListView::slotCurrentImgFlush(QPixmap pix, const QSize &originalS
     data.imgOriginalWidth = originalSize.width();
     data.imgOriginalHeight = originalSize.height();
     data.image = pix.toImage();
+
+    // FIX:暂时修复，用于解决某些场景下初始化，图片全数据还未处理完成（多线程处理）
+    // data.imageType 还未设置的情况
+    if (data.imageType == imageViewerSpace::ImageTypeBlank) {
+        data.imageType = LibUnionImage_NameSpace::getImageType(data.path);
+    }
+
     QVariant meta;
     meta.setValue(data);
     m_model->setData(currentIndex, meta, Qt::DisplayRole);

--- a/libimageviewer/viewpanel/scen/imagegraphicsview.cpp
+++ b/libimageviewer/viewpanel/scen/imagegraphicsview.cpp
@@ -1526,35 +1526,36 @@ void LibImageGraphicsView::addLoadSpinner(bool enhanceImage)
         m_spinner = new DSpinner(this);
         m_spinner->setFixedSize(SPINNER_SIZE);
 
-        QWidget *w = new QWidget(this);
-        w->setFixedSize(SPINNER_SIZE);
+        m_spinnerCtx = new QWidget(this);
+        m_spinnerCtx->setFixedSize(SPINNER_SIZE);
         QVBoxLayout *hLayout = new QVBoxLayout;
         hLayout->setMargin(0);
         hLayout->setSpacing(0);
         hLayout->addWidget(m_spinner, 0, Qt::AlignCenter);
 
         // 图像增强增加文案，默认隐藏
-        w->setFixedWidth(300);
-        w->setFixedHeight(70);
-        m_spinnerLabel = new QLabel(w);
+        m_spinnerCtx->setFixedWidth(300);
+        m_spinnerCtx->setFixedHeight(70);
+        m_spinnerLabel = new QLabel(m_spinnerCtx);
         m_spinnerLabel->setText(tr("AI retouching in progress, please wait..."));
         m_spinnerLabel->setVisible(false);
         hLayout->addWidget(m_spinnerLabel, 1, Qt::AlignBottom | Qt::AlignHCenter);
 
-        w->setLayout(hLayout);
+        m_spinnerCtx->setLayout(hLayout);
 
         if (!this->layout()) {
             QVBoxLayout *lay = new QVBoxLayout;
             lay->setAlignment(Qt::AlignCenter);
             this->setLayout(lay);
         }
-        this->layout()->addWidget(w);
+        this->layout()->addWidget(m_spinnerCtx);
     }
 
-    m_spinnerLabel->setVisible(enhanceImage);
-
-    m_spinner->setVisible(true);
     m_spinner->start();
+
+    m_spinnerCtx->setVisible(true);
+    m_spinner->setVisible(true);
+    m_spinnerLabel->setVisible(enhanceImage);
 }
 
 /**
@@ -1562,6 +1563,10 @@ void LibImageGraphicsView::addLoadSpinner(bool enhanceImage)
  */
 void LibImageGraphicsView::hideSpinner()
 {
+    if (m_spinnerCtx) {
+        m_spinnerCtx->hide();
+    }
+
     if (m_spinner) {
         m_spinner->stop();
         m_spinner->hide();

--- a/libimageviewer/viewpanel/scen/imagegraphicsview.h
+++ b/libimageviewer/viewpanel/scen/imagegraphicsview.h
@@ -257,7 +257,8 @@ private:
     bool m_isFistOpen = true;
 
     //加载旋转
-    DSpinner *m_spinner{nullptr};
+    QWidget *m_spinnerCtx = nullptr;    // 旋转控制窗口
+    DSpinner *m_spinner = nullptr;
     QLabel *m_spinnerLabel = nullptr;
     int TITLEBAR_HEIGHT = 50;
 

--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -1436,13 +1436,6 @@ void LibViewPanel::slotChangeShowTopBottom()
     slotBottomMove();
 }
 
-bool LibViewPanel::event(QEvent *e)
-{
-
-
-    return QFrame::event(e);
-}
-
 bool LibViewPanel::slotOcrPicture()
 {
     if (!m_ocrInterface) {
@@ -2114,6 +2107,10 @@ void LibViewPanel::mousePressEvent(QMouseEvent *event)
 
 void LibViewPanel::dragEnterEvent(QDragEnterEvent *event)
 {
+    if (m_AIEnhancing) {
+        return;
+    }
+
     const QMimeData *mimeData = event->mimeData();
     if (!pluginUtils::base::checkMimeData(mimeData)) {
         return;
@@ -2131,6 +2128,10 @@ void LibViewPanel::dragMoveEvent(QDragMoveEvent *event)
 
 void LibViewPanel::dropEvent(QDropEvent *event)
 {
+    if (m_AIEnhancing) {
+        return;
+    }
+
     QList<QUrl> urls = event->mimeData()->urls();
     if (urls.isEmpty()) {
         return;
@@ -2330,6 +2331,12 @@ void LibViewPanel::resetAIEnhanceImage()
 void LibViewPanel::onEnhanceStart()
 {
     m_AIEnhancing = true;
+
+    // 复位界面，隐藏导航窗口，显示标题/工具栏
+    if (m_nav->isVisible()) {
+        m_nav->setVisible(false);
+    }
+    Q_EMIT m_view->sigImageOutTitleBar(false);
 
     blockInputControl(true);
     setAIBtnVisible(false);

--- a/libimageviewer/viewpanel/viewpanel.h
+++ b/libimageviewer/viewpanel/viewpanel.h
@@ -177,8 +177,6 @@ public slots:
     void slotChangeShowTopBottom();
 
 protected:
-    bool event(QEvent *e) override;
-
     void resizeEvent(QResizeEvent *e) override;
     void showEvent(QShowEvent *e) override;
     void paintEvent(QPaintEvent *event) override;


### PR DESCRIPTION
1. 初始化时多线程加载图片信息，在低性能机型上， 获取首张缩略图信息时，图片全加载信息还未更新， 仅取得图片大小，因此在设置缩略图时， 若内部图片类型为空，手动更新图片类型；
2. 打印过程中屏蔽拖拽切换图片接口；
3. 优化界面，调整打印信息。

Log: 修复部分问题
Bug: https://pms.uniontech.com/bug-view-232295.html
Bug: https://pms.uniontech.com/bug-view-232301.html
Influence: InitImageType DragImage
Change-Id: Ifb21d78859fe2d43777ecb9b61ee0414477c4cd5