### PR TITLE
chore: Bump version to 1.0.38

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+image-editor (1.0.39) unstable; urgency=medium
+
+  * fix: compact mode build faild on low dtkgui version.
+         (Influence: CompactMode)
+  * fix: remove unnecessary dependency packages
+  * feat: Add AI image enhance support.(Influence: AIModel)
+  * fix: Init type error / disable drag in processing.
+         (Bug: 232295, 232301)(Influence: InitImageType DragImage)
+  * fix: Action using enhance image instead of source.
+         (Bug: 232505)(Influence: Menu)
+  * fix: Disable album action with enhance image.
+         (Bug: 232505)(Influence: Menu)
+  * fix: diff color with bottom bar and enhance bar.(Influence: EnhaceBar)
+  * feat: Disable enhance image size limit.
+  * fix: Add file unsavable notify dialog.
+
+ -- renbin <renbin@uniontech.com>  Tue, 12 Dec 2023 17:01:47 +0800
+
 image-editor (1.0.38) unstable; urgency=medium
 
   * chore: Update REUSE date


### PR DESCRIPTION
Bump version to 1.0.38
PR:
* https://github.com/linuxdeepin/image-editor/pull/102
* https://github.com/linuxdeepin/image-editor/pull/103
* https://github.com/linuxdeepin/image-editor/pull/104
* https://github.com/linuxdeepin/image-editor/pull/105
* https://github.com/linuxdeepin/image-editor/pull/106
* https://github.com/linuxdeepin/image-editor/pull/107
* https://github.com/linuxdeepin/image-editor/pull/108

Log: Bump version to 1.0.38
Change-Id: I89b1bc5ec7e86cd74b3bad0e3fc9f94c81473d67