### PR TITLE
chore: Bump version to 1.0.40

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+image-editor (1.0.40) unstable; urgency=medium
+
+  * fix: Build error on low dtk version.
+
+ -- renbin <renbin@uniontech.com>  Mon, 25 Dec 2023 17:14:57 +0800
+
 image-editor (1.0.39) unstable; urgency=medium
 
   * fix: compact mode build faild on low dtkgui version.


### PR DESCRIPTION
Bump version to 1.0.40
PR:
* https://github.com/linuxdeepin/image-editor/pull/111

Log: Bump version to 1.0.40
Change-Id: Ieb7c73c9cccb42dfa5b93b953a5e489aba0572df