### PR TITLE
fix: Delete image not work after rename.

### DIFF
--- a/libimageviewer/viewpanel/contents/bottomtoolbar.cpp
+++ b/libimageviewer/viewpanel/contents/bottomtoolbar.cpp
@@ -256,11 +256,12 @@ void LibBottomToolbar::checkAdaptScreenBtn()
 
 void LibBottomToolbar::deleteImage()
 {
-    if (m_imgListWidget->getImgCount() == 0)
-        return;
     //移除正在展示照片
     if (m_imgListWidget) {
-        QString path = m_imgListWidget->getCurrentPath();
+        if (m_imgListWidget->getImgCount() == 0)
+            return;
+
+        QString path = getCurrentItemInfo().path;
 
         QFile file(path);
         if (!file.exists()) {
@@ -373,7 +374,7 @@ void LibBottomToolbar::onTrashBtnClicked()
     //更换删除顺序,相册需要现在显示删除,再删除本体
     QString path;
     if (m_imgListWidget) {
-        path = m_imgListWidget->getCurrentPath();
+        path = getCurrentItemInfo().path;
     }
     if (path.isEmpty() && m_currentpath.isEmpty()) {
         path = m_currentpath;

--- a/libimageviewer/viewpanel/contents/imgviewlistview.cpp
+++ b/libimageviewer/viewpanel/contents/imgviewlistview.cpp
@@ -289,10 +289,17 @@ void LibImgViewListView::slotOneImgReady(QString path, imageViewerSpace::ItemInf
         if (data.path == path) {
             pix.imgWidth = data.imgWidth;
             pix.imgHeight = data.imgHeight;
-//            cutPixmap(pix);
+
+            // 更新文件信息
             QVariant meta;
             meta.setValue(pix);
             m_model->setData(index, meta, Qt::DisplayRole);
+
+            // 判断当前的文件路径是否变更(重命名时)，若变更则更新
+            if (path == m_currentPath && pix.path != m_currentPath) {
+                m_currentPath = pix.path;
+            }
+
             this->update(index);
             this->viewport()->update();
             break;


### PR DESCRIPTION
旧版看图存在多种取得当前图片的接口,
删除图片文件使用的接口所指向的文件路径
变量在重命名后未更新.
调整取得当前图片路径的接口,和其它代码
保持一致.同时更新重命名后当前图片路径
变量用于其它内部处理获取正确信息.

Log: 修复重命名后删除图片无响应.
Bug: https://pms.uniontech.com/bug-view-236589.html
Influence: Delete
Change-Id: I1e54f3f289e3d88ec84afed686ad16bd0137a73f