### PR TITLE
chore: Bump version to 1.0.41

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+image-editor (1.0.41) unstable; urgency=medium
+
+  * fix: Delete image not work after rename.(Bug: 236589)
+
+ -- renbin <renbin@uniontech.com>  Wed, 10 Jan 2024 13:38:35 +0800
+
 image-editor (1.0.40) unstable; urgency=medium
 
   * fix: Build error on low dtk version.


### PR DESCRIPTION
Bump version to 1.0.41
PR:
* https://github.com/linuxdeepin/image-editor/pull/113

Log: Bump version to 1.0.41
Change-Id: I2810650f972d751b0a14535b8e9b25ca29329a71