### PR TITLE
feat: Merge permission/watermark into master

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,10 @@
+[main]
+host = https://www.transifex.com
+minimum_perc = 80
+mode = developer
+
+[o:linuxdeepin:p:libimage-viewer:r:libimage-viewer]
+file_filter = src/libimageviewer/translations/libimageviewer_<lang>.ts
+source_file = src/libimageviewer/translations/libimageviewer.ts
+source_lang = en
+type = QT

--- a/.tx/deepin.conf
+++ b/.tx/deepin.conf
@@ -1,1 +1,2 @@
 [transifex]
+branch = m20

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ message(STATUS ${CMAKE_CXX_FLAGS})
 
 option(DOTEST "option for test" OFF)
 
-if(DOTEST)
+if(DOTEST OR CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_subdirectory(tests)
 endif()
 

--- a/libimageviewer/imageengine.cpp
+++ b/libimageviewer/imageengine.cpp
@@ -15,6 +15,7 @@
 #include "service/commonservice.h"
 #include "unionimage/imgoperate.h"
 #include "unionimage/unionimage.h"
+#include "service/permissionconfig.h"
 #include "service/imagedataservice.h"
 class ImageEnginePrivate
 {
@@ -32,6 +33,8 @@ public:
 ImageEnginePrivate::ImageEnginePrivate(ImageEngine *parent): q_ptr(parent)
 {
     Q_Q(ImageEngine);
+    // 关联授权操作通知信号
+    QObject::connect(PermissionConfig::instance(), &PermissionConfig::authoriseNotify, q, &ImageEngine::sigAuthoriseNotify);
 
     QThread *workerThread = new QThread(q_ptr);
     m_worker = new LibImgOperate(workerThread);

--- a/libimageviewer/imageengine.h
+++ b/libimageviewer/imageengine.h
@@ -30,7 +30,6 @@ public:
     //是否是可选转的图片
     bool isRotatable(const QString &path);
 
-
     //根据文件路径制作md5
     QString makeMD5(const QString &path);
 
@@ -53,14 +52,14 @@ signals:
     void sigGetAlbumName(const QString &path);
     //添加到已有相册/新建相册
     void sigAddToAlbum(bool isNew, const QString &album, const QString &path);
-    void sigAddToAlbumWithUID(bool isNew, int UID, const QString &path); //采用UID方案的添加至相册
+    void sigAddToAlbumWithUID(bool isNew, int UID, const QString &path);  //采用UID方案的添加至相册
     //收藏/取消收藏
     void sigAddOrRemoveToFav(const QString &path, bool isAdd);
     //导出
     void sigExport(const QString &path);
     //从自定义相册中移除
     void sigRemoveFromCustom(const QString &path, const QString &album);
-    void sigRemoveFromCustomWithUID(const QString &path, int UID); //采用UID方案的从相册中删除
+    void sigRemoveFromCustomWithUID(const QString &path, int UID);  //采用UID方案的从相册中删除
     //退出幻灯片
     void exitSlideShow();
     //按下ESC键
@@ -68,12 +67,14 @@ signals:
     //通知旋转
     void sigRotatePic(const QString &path);
 
-private:
+    // 授权操作通知信号
+    void sigAuthoriseNotify(const QJsonObject &data);
 
+private:
     static ImageEngine *m_ImageEngine;
 
     QScopedPointer<ImageEnginePrivate> d_ptr;
     Q_DECLARE_PRIVATE_D(qGetPtrHelper(d_ptr), ImageEngine)
 };
 
-#endif // IMAGEENGINE_H
+#endif  // IMAGEENGINE_H

--- a/libimageviewer/imageviewer.cpp
+++ b/libimageviewer/imageviewer.cpp
@@ -13,6 +13,7 @@
 #include <QDirIterator>
 #include <QTranslator>
 #include <DFileDialog>
+#include <dtkwidget_config.h>
 
 #include "imageengine.h"
 #include "viewpanel/viewpanel.h"
@@ -22,7 +23,7 @@
 #include "unionimage/imageutils.h"
 #include "unionimage/baseutils.h"
 
-#ifndef DISABLE_WATERMARK
+#ifdef DTKWIDGET_CLASS_DWaterMarkHelper
 #include <DWaterMarkHelper>
 #endif
 
@@ -85,7 +86,7 @@ ImageViewerPrivate::ImageViewerPrivate(imageViewerSpace::ImgViewerType imgViewer
     m_panel = new LibViewPanel(customTopToolbar, q);
     layout->addWidget(m_panel);
 
-#ifndef DISABLE_WATERMARK
+#ifdef DTKWIDGET_CLASS_DWaterMarkHelper
     // 设置看图水印，目前仅在主要展示区域显示
     if (PermissionConfig::instance()->hasReadWaterMark()) {
         auto data = PermissionConfig::instance()->readWaterMarkData();

--- a/libimageviewer/imageviewer.cpp
+++ b/libimageviewer/imageviewer.cpp
@@ -87,7 +87,7 @@ ImageViewerPrivate::ImageViewerPrivate(imageViewerSpace::ImgViewerType imgViewer
 
 #ifndef DISABLE_WATERMARK
     // 设置看图水印，目前仅在主要展示区域显示
-    if (PermissionConfig::instance()->isValid()) {
+    if (PermissionConfig::instance()->hasReadWaterMark()) {
         auto data = PermissionConfig::instance()->readWaterMarkData();
         DWaterMarkHelper::instance()->setData(data);
         DWaterMarkHelper::instance()->registerWidget(m_panel);

--- a/libimageviewer/service/permissionconfig.cpp
+++ b/libimageviewer/service/permissionconfig.cpp
@@ -376,7 +376,7 @@ void PermissionConfig::initFromArguments()
                 triggerOpen(targetImagePath);
             }
 
-            qInfo() << qPrintable("Current Enable permission") << authFlags);
+            qInfo() << qPrintable("Current Enable permission") << authFlags;
         } else {
             qWarning()
                 << QString("Parse authorise config error at pos: %1, details: %2").arg(error.offset).arg(error.errorString());

--- a/libimageviewer/service/permissionconfig.cpp
+++ b/libimageviewer/service/permissionconfig.cpp
@@ -1,0 +1,531 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "permissionconfig.h"
+#include "imageengine.h"
+
+#include <QApplication>
+#include <QJsonDocument>
+#include <QFileInfo>
+#include <QDebug>
+
+const QString g_KeyTid = "tid";
+const QString g_KeyOperate = "operate";
+const QString g_KeyFilePath = "filePath";
+const QString g_KeyRemaining = "remainingPrintCount";
+
+/**
+   @class AuthoriseConfig
+   @brief 授权控制类，提供操作授权和水印配置
+   @details 授权控制主要包括编辑、拷贝、删除、保存等操作，水印包括阅读水印及打印水印。
+    配置信息通过命令行参数获取，当授权控制开启时，进行主要操作将自动发送通知信息。
+   @note 此类非线程安全
+ */
+
+/**
+   @brief 构造函数，构造时即初始化配置
+ */
+PermissionConfig::PermissionConfig(QObject *parent)
+    : QObject(parent)
+{
+#ifdef DISABLE_WATERMARK
+    qWarning() << qPrintable("Current version is not support read watermark");
+#endif
+}
+
+/**
+   @brief 析构函数
+ */
+PermissionConfig::~PermissionConfig() {}
+
+/**
+   @return 返回权限控制单实例
+ */
+PermissionConfig *PermissionConfig::instance()
+{
+    static PermissionConfig config;
+    return &config;
+}
+
+/**
+   @return 是否允许进行权限控制，未加载授权配置时返回 false
+ */
+bool PermissionConfig::isValid() const
+{
+    return valid;
+}
+
+/**
+   @return 返回当前是否为权限控制目标图片
+ */
+bool PermissionConfig::isCurrentIsTargetImage() const
+{
+    return isValid() && currentImagePath == targetImagePath;
+}
+
+/**
+   @return 是否允许编辑图片，无授权控制时默认返回 true
+ */
+bool PermissionConfig::isEditable(const QString &fileName) const
+{
+    if (checkAuthInvalid(fileName)) {
+        return true;
+    }
+
+    return authFlags.testFlag(EnableEdit);
+}
+
+/**
+   @return 是否允许复制图片，无授权控制时默认返回 true
+ */
+bool PermissionConfig::isCopyable(const QString &fileName) const
+{
+    if (checkAuthInvalid(fileName)) {
+        return true;
+    }
+
+    return authFlags.testFlag(EnableCopy);
+}
+
+/**
+   @return 是否允许删除图片，无授权控制时默认返回 true
+ */
+bool PermissionConfig::isDeletable() const
+{
+    if (checkAuthInvalid()) {
+        return true;
+    }
+
+    return authFlags.testFlag(EnableDelete);
+}
+
+/**
+   @return 是否允许重命名图片，无授权控制时默认返回 true
+ */
+bool PermissionConfig::isRenamable() const
+{
+    if (checkAuthInvalid()) {
+        return true;
+    }
+
+    return authFlags.testFlag(EnableRename);
+}
+
+/**
+   @return 是否允许切换图片，无授权控制时默认返回 true
+ */
+bool PermissionConfig::isSwitchable() const
+{
+    if (checkAuthInvalid()) {
+        return true;
+    }
+
+    return authFlags.testFlag(EnableSwitch);
+}
+
+/**
+   @return
+   @note -1 表示无限制;0 表示无打印次数;1~表示剩余可打印次数
+ */
+bool PermissionConfig::isPrintable(const QString &fileName) const
+{
+    if (checkAuthInvalid(fileName)) {
+        return true;
+    }
+
+    return !!printLimitCount;
+}
+
+/**
+   @brief 触发打开文件 \a fileName ，若为限权文件，向外发送权限通知信号
+ */
+void PermissionConfig::triggerOpen(const QString &fileName)
+{
+    if (checkAuthInvalid(fileName)) {
+        return;
+    }
+
+    if (NotOpen != status) {
+        return;
+    }
+    status = Open;
+
+    QJsonObject data{{g_KeyTid, TidOpen}, {g_KeyOperate, "open"}, {g_KeyFilePath, fileName}};
+
+    triggerNotify(data);
+}
+
+/**
+   @brief 触发编辑文件 \a fileName ，若为限权文件，向外发送权限通知信号
+ */
+void PermissionConfig::triggerEdit(const QString &fileName)
+{
+    if (checkAuthInvalid(fileName)) {
+        return;
+    }
+
+    QJsonObject data{{g_KeyTid, TidEdit}, {g_KeyOperate, "edit"}, {g_KeyFilePath, fileName}};
+
+    triggerNotify(data);
+}
+
+/**
+   @brief 触发拷贝文件 \a fileName ，若为限权文件，向外发送权限通知信号
+ */
+void PermissionConfig::triggerCopy(const QString &fileName)
+{
+    if (checkAuthInvalid(fileName)) {
+        return;
+    }
+
+    QJsonObject data{{g_KeyTid, TidCopy}, {g_KeyOperate, "copy"}, {g_KeyFilePath, fileName}};
+
+    triggerNotify(data);
+}
+
+/**
+   @brief 触发删除文件 \a fileName ，若为限权文件，向外发送权限通知信号
+ */
+void PermissionConfig::triggerDelete(const QString &fileName)
+{
+    if (checkAuthInvalid(fileName)) {
+        return;
+    }
+
+    QJsonObject data{{g_KeyTid, TidDelete}, {g_KeyOperate, "delete"}, {g_KeyFilePath, fileName}};
+
+    triggerNotify(data);
+}
+
+/**
+   @brief 触发重命名文件 \a fileName ，若为限权文件，向外发送权限通知信号
+ */
+void PermissionConfig::triggerRename(const QString &fileName)
+{
+    if (checkAuthInvalid()) {
+        return;
+    }
+
+    QJsonObject data{{g_KeyTid, TidRename}, {g_KeyOperate, "rename"}, {g_KeyFilePath, fileName}};
+
+    triggerNotify(data);
+}
+
+/**
+   @brief 触发打印文件 \a fileName ，若为限权文件，向外发送权限通知信号
+ */
+void PermissionConfig::triggerPrint(const QString &fileName)
+{
+    if (checkAuthInvalid()) {
+        return;
+    }
+
+    // 减少打印计数
+    reduceOnePrintCount();
+    QJsonObject data{{g_KeyTid, TidPrint}, {g_KeyOperate, "print"}, {g_KeyFilePath, fileName}, {g_KeyRemaining, printCount()}};
+
+    triggerNotify(data);
+}
+
+/**
+   @brief 触发关闭文件 \a fileName ，若为限权文件，向外发送权限通知信号
+ */
+void PermissionConfig::triggerClose(const QString &fileName)
+{
+    if (checkAuthInvalid(fileName)) {
+        return;
+    }
+
+    if (Open != status) {
+        return;
+    }
+    status = Close;
+
+    QJsonObject data{{"tid", TidClose}, {g_KeyOperate, "close"}, {g_KeyFilePath, fileName}};
+
+    triggerNotify(data);
+}
+
+/**
+   @brief 返回当前剩余的打印次数
+   @sa `isPrintable`
+ */
+int PermissionConfig::printCount() const
+{
+    return printLimitCount;
+}
+
+/**
+   @brief 返回是否打印无限制
+ */
+bool PermissionConfig::isUnlimitPrint() const
+{
+    if (checkAuthInvalid()) {
+        return true;
+    }
+    return -1 == printLimitCount;
+}
+
+/**
+   @brief 减少一次打印计数并发送打印计数变更信号 `printCountChanged`
+ */
+void PermissionConfig::reduceOnePrintCount()
+{
+    if (printLimitCount > 0) {
+        printLimitCount--;
+        Q_EMIT printCountChanged();
+    } else {
+        qWarning() << "Escape print authorise check!";
+    }
+}
+
+/**
+   @brief 触发权限操作通知，将向外发送Json数据，通过DBus广播
+ */
+void PermissionConfig::triggerNotify(const QJsonObject &data)
+{
+    enum ReportMode { Broadcast = 1, Report = 2, ReportAndBroadcast = Broadcast | Report };
+    QJsonObject sendData;
+    sendData.insert("policy", QJsonObject{{"reportMode", ReportAndBroadcast}});
+    sendData.insert("info", data);
+
+    Q_EMIT authoriseNotify(sendData);
+}
+
+/**
+   @brief 设置当前处理的文件路径为 \a fileName
+ */
+void PermissionConfig::setCurrentImagePath(const QString &fileName)
+{
+    currentImagePath = fileName;
+}
+
+/**
+   @return 返回当前控制的图片路径
+ */
+QString PermissionConfig::targetImage() const
+{
+    return targetImagePath;
+}
+
+#ifndef DISABLE_WATERMARK
+
+/**
+   @return 返回从配置中读取的阅读水印配置，用于图片展示时显示
+ */
+WaterMarkData PermissionConfig::readWaterMarkData() const
+{
+    return readWaterMark;
+}
+
+/**
+   @return 返回从配置中读取的打印水印配置，用于图片打印预览及打印时显示
+ */
+WaterMarkData PermissionConfig::printWaterMarkData() const
+{
+    return printWaterMark;
+}
+
+#endif
+
+/**
+   @brief 从命令行参数中取得授权配置
+   @note 命令行参数示例：
+    deepin-image-viewer --config=[Base64 code data] /path/to/file
+ */
+void PermissionConfig::initFromArguments()
+{
+    if (valid) {
+        return;
+    }
+
+    QString configParam = parseConfigOption();
+    if (!configParam.isEmpty()) {
+        // 获取带权限控制的文件路径
+        QStringList arguments = qApp->arguments();
+        for (const QString &arg : arguments) {
+            QFileInfo info(arg);
+            QString filePath = info.absoluteFilePath();
+            if (ImageEngine::instance()->isImage(filePath) || info.suffix() == "dsps") {
+                targetImagePath = filePath;
+                break;
+            }
+        }
+
+        if (targetImagePath.isEmpty()) {
+            qWarning() << qPrintable("Authorise config with no target image path.") << arguments;
+            return;
+        }
+
+        QByteArray jsonData = QByteArray::fromBase64(configParam.toUtf8());
+        qInfo() << QString("Parse authorise config, data: %1").arg(QString(jsonData));
+
+        QJsonParseError error;
+        QJsonDocument doc = QJsonDocument::fromJson(jsonData, &error);
+
+        if (!doc.isNull()) {
+            QJsonObject root = doc.object();
+            initAuthorise(root.value("permission").toObject());
+            initReadWaterMark(root.value("readWatermark").toObject());
+            initPrintWaterMark(root.value("printWatermark").toObject());
+
+            valid = !targetImagePath.isEmpty();
+            if (valid) {
+                // 首次触发打开图片
+                triggerOpen(targetImagePath);
+            }
+
+            qInfo() << qPrintable("Current Enable permission") << authFlags);
+        } else {
+            qWarning()
+                << QString("Parse authorise config error at pos: %1, details: %2").arg(error.offset).arg(error.errorString());
+        }
+    } else {
+        qWarning() << qPrintable("Parse authorise config is empty.");
+    }
+}
+
+/**
+   @return 解析命令行参数并返回设置的权限和水印配置，为设置则返回空
+ */
+QString PermissionConfig::parseConfigOption()
+{
+    if (!qApp) {
+        qWarning() << qPrintable("Must init authorise config after QApplication initialized");
+        return {};
+    }
+
+    const QString option("--config");
+    const QLatin1Char assignChar('=');
+    enum Status { FindOption, FindAssign, FindParam };
+    Status status = FindOption;
+
+    QStringList arguments = qApp->arguments();
+    for (const QString &arg : arguments) {
+        switch (status) {
+            case FindOption:
+                if (arg.simplified().startsWith(option)) {
+                    int index = arg.indexOf(assignChar);
+                    if (index < 0) {
+                        status = FindAssign;
+                        continue;
+                    } else if (index == arg.length() - 1) {
+                        status = FindParam;
+                        continue;
+                    } else {
+                        return arg.mid(index + 1);
+                    }
+                }
+                break;
+            case FindAssign:
+                if (arg.simplified().startsWith(assignChar)) {
+                    if (arg.length() > 1) {
+                        return arg.mid(1);
+                    } else {
+                        status = FindParam;
+                        continue;
+                    }
+                } else {
+                    return {};
+                }
+                break;
+            case FindParam:
+                return arg;
+        }
+    }
+
+    return {};
+}
+
+/**
+   @brief 从 Json 配置 \a param 中取得授权信息
+ */
+void PermissionConfig::initAuthorise(const QJsonObject &param)
+{
+    if (param.isEmpty()) {
+        qInfo() << qPrintable("Authorise config not contains authorise data.");
+        return;
+    }
+
+    // 屏蔽 delete / rename ，默认无此功能
+    authFlags.setFlag(EnableEdit, param.value("edit").toBool(false));
+    authFlags.setFlag(EnableCopy, param.value("copy").toBool(false));
+    // 默认允许切换图片，包括快捷键及 Ctrl + O
+    authFlags.setFlag(EnableSwitch, true);
+
+    printLimitCount = param.value("printCount").toInt(0);
+}
+
+/**
+   @brief 从 Json 配置 \a param 中取得阅读水印信息
+ */
+void PermissionConfig::initReadWaterMark(const QJsonObject &param)
+{
+    if (param.isEmpty()) {
+        qInfo() << qPrintable("Authorise config not contains read watermark data.");
+        return;
+    }
+
+#ifndef DISABLE_WATERMARK
+    readWaterMark.type = WaterMarkType::Text;
+    readWaterMark.font.setFamily(param.value("font").toString());
+    readWaterMark.font.setPixelSize(param.value("fontSize").toInt());
+
+    QString colorName = param.value("color").toString();
+    if (!colorName.startsWith('#')) {
+        colorName.prepend('#');
+    }
+    readWaterMark.color.setNamedColor(colorName);
+    readWaterMark.opacity = param.value("opacity").toDouble() / 255;
+    readWaterMark.layout = param.value("layout").toInt() ? WaterMarkLayout::Tiled : WaterMarkLayout::Center;
+    readWaterMark.rotation = param.value("angle").toDouble();
+    readWaterMark.lineSpacing = param.value("rowSpacing").toInt();
+    readWaterMark.spacing = param.value("columnSpacing").toInt();
+    readWaterMark.text = param.value("text").toString();
+#endif
+}
+
+/**
+   @brief 从 Json 配置 \a param 中取得打印水印信息
+ */
+void PermissionConfig::initPrintWaterMark(const QJsonObject &param)
+{
+    if (param.isEmpty()) {
+        qInfo() << qPrintable("Authorise config not contains print watermark data.");
+        return;
+    }
+
+#ifndef DISABLE_WATERMARK
+    printWaterMark.type = WaterMarkType::Text;
+    printWaterMark.font.setFamily(param.value("font").toString());
+    printWaterMark.font.setPixelSize(param.value("fontSize").toInt());
+
+    QString colorName = param.value("color").toString();
+    if (!colorName.startsWith('#')) {
+        colorName.prepend('#');
+    }
+    printWaterMark.color.setNamedColor(colorName);
+    printWaterMark.opacity = param.value("opacity").toDouble() / 255;
+    printWaterMark.layout = param.value("layout").toInt() ? WaterMarkLayout::Tiled : WaterMarkLayout::Center;
+    printWaterMark.rotation = param.value("angle").toDouble();
+    printWaterMark.lineSpacing = param.value("rowSpacing").toInt();
+    printWaterMark.spacing = param.value("columnSpacing").toInt();
+    printWaterMark.text = param.value("text").toString();
+#endif
+}
+
+/**
+   @return 返回文件 \a fileName 是否需要被校验权限
+ */
+bool PermissionConfig::checkAuthInvalid(const QString &fileName) const
+{
+    if (!isValid()) {
+        return true;
+    }
+    if (fileName.isEmpty()) {
+        return currentImagePath != targetImagePath;
+    }
+
+    return fileName != targetImagePath;
+}

--- a/libimageviewer/service/permissionconfig.cpp
+++ b/libimageviewer/service/permissionconfig.cpp
@@ -125,7 +125,7 @@ bool PermissionConfig::isSwitchable() const
 }
 
 /**
-   @return
+   @return 是否允许打印图片，无授权控制时默认返回 true
    @note -1 表示无限制;0 表示无打印次数;1~表示剩余可打印次数
  */
 bool PermissionConfig::isPrintable(const QString &fileName) const
@@ -135,6 +135,22 @@ bool PermissionConfig::isPrintable(const QString &fileName) const
     }
 
     return !!printLimitCount;
+}
+
+/**
+   @return 是否存在阅读水印
+ */
+bool PermissionConfig::hasReadWaterMark() const
+{
+    return authFlags.testFlag(EnableReadWaterMark);
+}
+
+/**
+   @return 是否存在打印水印
+ */
+bool PermissionConfig::hasPrintWaterMark() const
+{
+    return authFlags.testFlag(EnablePrintWaterMark);
 }
 
 /**
@@ -483,6 +499,8 @@ void PermissionConfig::initReadWaterMark(const QJsonObject &param)
     readWaterMark.lineSpacing = param.value("rowSpacing").toInt();
     readWaterMark.spacing = param.value("columnSpacing").toInt();
     readWaterMark.text = param.value("text").toString();
+
+    authFlags.setFlag(EnableReadWaterMark, true);
 #endif
 }
 
@@ -512,6 +530,8 @@ void PermissionConfig::initPrintWaterMark(const QJsonObject &param)
     printWaterMark.lineSpacing = param.value("rowSpacing").toInt();
     printWaterMark.spacing = param.value("columnSpacing").toInt();
     printWaterMark.text = param.value("text").toString();
+
+    authFlags.setFlag(EnablePrintWaterMark, true);
 #endif
 }
 

--- a/libimageviewer/service/permissionconfig.cpp
+++ b/libimageviewer/service/permissionconfig.cpp
@@ -456,7 +456,7 @@ void PermissionConfig::initReadWaterMark(const QJsonObject &param)
 #ifdef DTKWIDGET_CLASS_DWaterMarkHelper
     readWaterMark.type = WaterMarkType::Text;
     readWaterMark.font.setFamily(param.value("font").toString());
-    readWaterMark.font.setPixelSize(param.value("fontSize").toInt());
+    readWaterMark.font.setPointSize(param.value("fontSize").toInt());
 
     QString colorName = param.value("color").toString();
     if (!colorName.startsWith('#')) {

--- a/libimageviewer/service/permissionconfig.cpp
+++ b/libimageviewer/service/permissionconfig.cpp
@@ -29,7 +29,7 @@ const QString g_KeyRemaining = "remainingPrintCount";
 PermissionConfig::PermissionConfig(QObject *parent)
     : QObject(parent)
 {
-#ifdef DISABLE_WATERMARK
+#ifndef DTKWIDGET_CLASS_DWaterMarkHelper
     qWarning() << qPrintable("Current version is not support read watermark");
 #endif
 }
@@ -325,7 +325,7 @@ QString PermissionConfig::targetImage() const
     return targetImagePath;
 }
 
-#ifndef DISABLE_WATERMARK
+#ifdef DTKWIDGET_CLASS_DWaterMarkHelper
 
 /**
    @return 返回从配置中读取的阅读水印配置，用于图片展示时显示
@@ -483,7 +483,7 @@ void PermissionConfig::initReadWaterMark(const QJsonObject &param)
         return;
     }
 
-#ifndef DISABLE_WATERMARK
+#ifdef DTKWIDGET_CLASS_DWaterMarkHelper
     readWaterMark.type = WaterMarkType::Text;
     readWaterMark.font.setFamily(param.value("font").toString());
     readWaterMark.font.setPixelSize(param.value("fontSize").toInt());
@@ -514,7 +514,7 @@ void PermissionConfig::initPrintWaterMark(const QJsonObject &param)
         return;
     }
 
-#ifndef DISABLE_WATERMARK
+#ifdef DTKWIDGET_CLASS_DWaterMarkHelper
     printWaterMark.type = WaterMarkType::Text;
     printWaterMark.font.setFamily(param.value("font").toString());
     printWaterMark.font.setPixelSize(param.value("fontSize").toInt());

--- a/libimageviewer/service/permissionconfig.h
+++ b/libimageviewer/service/permissionconfig.h
@@ -12,6 +12,7 @@
 
 #ifdef DTKWIDGET_CLASS_DWaterMarkHelper
 #include <DWaterMarkHelper>
+#include <DPrintPreviewDialog>
 #include <dprintpreviewsettinginfo.h>
 
 DWIDGET_USE_NAMESPACE
@@ -84,6 +85,8 @@ public:
     Q_SLOT void activateProcess(qint64 pid);
     void initFromArguments(const QStringList &arguments);
 
+    bool installFilterPrintDialog(DPrintPreviewDialog *dialog);
+
 private:
     // 解析配置
     bool parseConfigOption(const QStringList &arguments, QString &configParam, QStringList &imageList) const;
@@ -97,6 +100,8 @@ private:
     void reduceOnePrintCount();
 
     void triggerNotify(const QJsonObject &data);
+
+    bool eventFilter(QObject *watched, QEvent *event) override;
 
 private:
     enum Status { NotOpen, Open, Close };
@@ -114,6 +119,10 @@ private:
     WaterMarkData readWaterMark;
     WaterMarkData printWaterMark;
 #endif  // DTKWIDGET_CLASS_DWaterMarkHelper
+
+    bool breakPrintSpacingLimit = false;    // 打破打印间距限制
+    qreal printRowSpacing = 0.0;
+    qreal printColumnSpacing = 0.0;
 };
 
 #endif  // PERMISSIONCONFIG_H

--- a/libimageviewer/service/permissionconfig.h
+++ b/libimageviewer/service/permissionconfig.h
@@ -90,6 +90,8 @@ private:
     void initAuthorise(const QJsonObject &param);
     void initReadWaterMark(const QJsonObject &param);
     void initPrintWaterMark(const QJsonObject &param);
+    void detectWaterMarkPluginExists();
+    bool initWaterMarkPluginEnvironment();
 
     bool checkAuthInvalid(const QString &fileName = QString()) const;
     void reduceOnePrintCount();
@@ -106,6 +108,7 @@ private:
     Status status = NotOpen;  // 被控制权限图片的状态
     Authorises authFlags = NoAuth;
 
+    bool useWaterMarkPlugin = false;  // 是否使用水印插件
 #ifdef DTKWIDGET_CLASS_DWaterMarkHelper
     WaterMarkData readWaterMark;
     WaterMarkData printWaterMark;

--- a/libimageviewer/service/permissionconfig.h
+++ b/libimageviewer/service/permissionconfig.h
@@ -8,9 +8,9 @@
 #include <QObject>
 #include <QJsonObject>
 
-// #define DISABLE_WATERMARK
+#include <dtkwidget_config.h>
 
-#ifndef DISABLE_WATERMARK
+#ifdef DTKWIDGET_CLASS_DWaterMarkHelper
 #include <DWaterMarkHelper>
 #include <dprintpreviewsettinginfo.h>
 
@@ -68,7 +68,7 @@ public:
     void setCurrentImagePath(const QString &fileName);
     QString targetImage() const;
 
-#ifndef DISABLE_WATERMARK
+#ifdef DTKWIDGET_CLASS_DWaterMarkHelper
     WaterMarkData readWaterMarkData() const;
     WaterMarkData printWaterMarkData() const;
 #endif
@@ -102,7 +102,7 @@ private:
     int printLimitCount = 0;
     Status status = NotOpen;  // 被控制权限图片的状态
     Authorises authFlags = NoAuth;
-#ifndef DISABLE_WATERMARK
+#ifdef DTKWIDGET_CLASS_DWaterMarkHelper
     WaterMarkData readWaterMark;
     WaterMarkData printWaterMark;
 #endif

--- a/libimageviewer/service/permissionconfig.h
+++ b/libimageviewer/service/permissionconfig.h
@@ -108,7 +108,8 @@ private:
     Status status = NotOpen;  // 被控制权限图片的状态
     Authorises authFlags = NoAuth;
 
-    bool useWaterMarkPlugin = false;  // 是否使用水印插件
+    bool ignoreDevicePixelRatio = false;    // 过滤设备显示比率，按照原生像素计算
+    bool useWaterMarkPlugin = false;        // 是否使用水印插件
 #ifdef DTKWIDGET_CLASS_DWaterMarkHelper
     WaterMarkData readWaterMark;
     WaterMarkData printWaterMark;

--- a/libimageviewer/service/permissionconfig.h
+++ b/libimageviewer/service/permissionconfig.h
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef PERMISSIONCONFIG_H
+#define PERMISSIONCONFIG_H
+
+#include <QObject>
+#include <QJsonObject>
+
+// #define DISABLE_WATERMARK
+
+#ifndef DISABLE_WATERMARK
+#include <DWaterMarkHelper>
+#include <dprintpreviewsettinginfo.h>
+
+DWIDGET_USE_NAMESPACE
+#endif
+
+class PermissionConfig : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int printCount READ printCount NOTIFY printCountChanged)
+
+    explicit PermissionConfig(QObject *parent = nullptr);
+    ~PermissionConfig() override;
+
+public:
+    static PermissionConfig *instance();
+    bool isValid() const;
+    bool isCurrentIsTargetImage() const;
+
+    enum Authorise {
+        NoAuth = 0,
+        EnableEdit = 0x1,
+        EnableCopy = 0x2,
+        EnableDelete = 0x4,
+        EnableRename = 0x8,
+        EnableSwitch = 0x10,
+    };
+    Q_DECLARE_FLAGS(Authorises, Authorise)
+
+    bool isEditable(const QString &fileName = QString()) const;
+    bool isCopyable(const QString &fileName = QString()) const;
+    bool isDeletable() const;
+    bool isRenamable() const;
+    bool isSwitchable() const;
+    bool isPrintable(const QString &fileName = QString()) const;
+
+    void triggerOpen(const QString &fileName);
+    void triggerEdit(const QString &fileName);
+    void triggerCopy(const QString &fileName);
+    void triggerDelete(const QString &fileName);
+    void triggerRename(const QString &fileName);
+    void triggerPrint(const QString &fileName);
+    void triggerClose(const QString &fileName);
+    Q_SIGNAL void authoriseNotify(const QJsonObject &data);
+
+    int printCount() const;
+    bool isUnlimitPrint() const;
+    Q_SIGNAL void printCountChanged();
+
+    void setCurrentImagePath(const QString &fileName);
+    QString targetImage() const;
+
+#ifndef DISABLE_WATERMARK
+    WaterMarkData readWaterMarkData() const;
+    WaterMarkData printWaterMarkData() const;
+#endif
+
+    void initFromArguments();
+
+private:
+    QString parseConfigOption();
+    void initAuthorise(const QJsonObject &param);
+    void initReadWaterMark(const QJsonObject &param);
+    void initPrintWaterMark(const QJsonObject &param);
+    bool checkAuthInvalid(const QString &fileName = QString()) const;
+    void reduceOnePrintCount();
+    void triggerNotify(const QJsonObject &data);
+
+private:
+    enum TidType {
+        TidOpen = 1000200050,
+        TidEdit = 1000200051,
+        TidCopy = 1000200052,
+        TidPrint = 1000200053,
+        TidClose = 1000200054,
+        TidDelete = 1000200055,
+        TidRename = 1000200056,
+    };
+    enum Status { NotOpen, Open, Close };
+
+    QString currentImagePath;  // 当前展示的图片文件路径
+    QString targetImagePath;   // 权限控制指向的文件路径
+    bool valid = false;
+    int printLimitCount = -1;
+    Status status = NotOpen;  // 被控制权限图片的状态
+    Authorises authFlags = NoAuth;
+#ifndef DISABLE_WATERMARK
+    WaterMarkData readWaterMark;
+    WaterMarkData printWaterMark;
+#endif
+};
+
+#endif  // PERMISSIONCONFIG_H

--- a/libimageviewer/service/permissionconfig.h
+++ b/libimageviewer/service/permissionconfig.h
@@ -37,6 +37,9 @@ public:
         EnableDelete = 0x4,
         EnableRename = 0x8,
         EnableSwitch = 0x10,
+
+        EnableReadWaterMark = 0x1000,
+        EnablePrintWaterMark = 0x2000,
     };
     Q_DECLARE_FLAGS(Authorises, Authorise)
 
@@ -46,6 +49,8 @@ public:
     bool isRenamable() const;
     bool isSwitchable() const;
     bool isPrintable(const QString &fileName = QString()) const;
+    bool hasReadWaterMark() const;
+    bool hasPrintWaterMark() const;
 
     void triggerOpen(const QString &fileName);
     void triggerEdit(const QString &fileName);
@@ -94,7 +99,7 @@ private:
     QString currentImagePath;  // 当前展示的图片文件路径
     QString targetImagePath;   // 权限控制指向的文件路径
     bool valid = false;
-    int printLimitCount = -1;
+    int printLimitCount = 0;
     Status status = NotOpen;  // 被控制权限图片的状态
     Authorises authFlags = NoAuth;
 #ifndef DISABLE_WATERMARK

--- a/libimageviewer/translations/libimageviewer.ts
+++ b/libimageviewer/translations/libimageviewer.ts
@@ -312,6 +312,14 @@
         <translation>Photo info</translation>
     </message>
     <message>
+        <source>(Disabled)</source>
+        <translation>(Disabled)</translation>
+    </message>
+    <message>
+        <source>(Remaining %1 times)</source>
+        <translation>(Remaining %1 times)</translation>
+    </message>
+    <message>
         <source>Colorize pictures</source>
         <translation type="unfinished"></translation>
     </message>

--- a/libimageviewer/translations/libimageviewer_es.ts
+++ b/libimageviewer/translations/libimageviewer_es.ts
@@ -240,7 +240,15 @@
     </message>
     <message>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Photo info</translation>
+    </message>
+    <message>
+        <source>(Disabled)</source>
+        <translation>(Disabled)</translation>
+    </message>
+    <message>
+        <source>(Remaining %1 times)</source>
+        <translation>(Remaining %1 times)</translation>
     </message>
 </context>
 <context>

--- a/libimageviewer/translations/libimageviewer_zh_CN.ts
+++ b/libimageviewer/translations/libimageviewer_zh_CN.ts
@@ -320,6 +320,14 @@
         <translation>照片信息</translation>
     </message>
     <message>
+        <source>(Disabled)</source>
+        <translation>（已禁用）</translation>
+    </message>
+    <message>
+        <source>(Remaining %1 times)</source>
+        <translation>（剩余 %1 次）</translation>
+    </message>
+    <message>
         <source>Retry</source>
         <translation type="unfinished">重 试</translation>
     </message>

--- a/libimageviewer/unionimage/baseutils.cpp
+++ b/libimageviewer/unionimage/baseutils.cpp
@@ -182,6 +182,10 @@ void showInFileManager(const QString &path)
 
 void copyImageToClipboard(const QStringList &paths)
 {
+    if (paths.isEmpty()) {
+        return;
+    }
+
     //  Get clipboard
 //    QClipboard *cb = QApplication::clipboard();
     QClipboard *cb = qApp->clipboard();
@@ -210,13 +214,14 @@ void copyImageToClipboard(const QStringList &paths)
     gnomeFormat.remove(gnomeFormat.length() - 1, 1);
     newMimeData->setData("x-special/gnome-copied-files", gnomeFormat);
 
-    // Copy Image Date
-//    QImage img(paths.first());
-//    Q_ASSERT(!img.isNull());
-//    newMimeData->setImageData(img);
+    // Copy Image Data
+    QImage img;
+    QString errMsg;
+    if (LibUnionImage_NameSpace::loadStaticImageFromFile(paths.first(), img, errMsg)) {
+        newMimeData->setImageData(img);
+    }
 
     // Set the mimedata
-//    cb->setMimeData(newMimeData);
     cb->setMimeData(newMimeData, QClipboard::Clipboard);
 }
 

--- a/libimageviewer/viewpanel/contents/bottomtoolbar.cpp
+++ b/libimageviewer/viewpanel/contents/bottomtoolbar.cpp
@@ -174,7 +174,7 @@ void LibBottomToolbar::setRotateBtnClicked(const bool &bRet)
 
 void LibBottomToolbar::setPictureDoBtnClicked(const bool &bRet)
 {
-    bool enableCopy = PermissionConfig::instance()->isCopyable();
+    bool enableCopy = PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableCopy);
 
     if (m_ocrIsExists && m_ocrBtn) {
         m_ocrBtn->setEnabled(bRet && enableCopy);
@@ -322,7 +322,7 @@ void LibBottomToolbar::deleteImage()
 
             m_imgListWidget->moveCenterWidget();
 
-            PermissionConfig::instance()->triggerDelete(path);
+            PermissionConfig::instance()->triggerAction(PermissionConfig::TidDelete, path);
         }
     }
 
@@ -484,7 +484,7 @@ void LibBottomToolbar::slotOpenImage(int index, QString path)
     PermissionConfig::instance()->setCurrentImagePath(info.absoluteFilePath());
     m_trashBtn->setVisible(!PermissionConfig::instance()->isCurrentIsTargetImage());
 
-    bool isCopyable = PermissionConfig::instance()->isCopyable();
+    bool isCopyable = PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableCopy);
     if (m_ocrIsExists) {
         if (isCopyable) {
             m_ocrBtn->setToolTip(QObject::tr("Extract text"));
@@ -507,7 +507,7 @@ void LibBottomToolbar::slotOpenImage(int index, QString path)
         m_adaptImageBtn->setEnabled(true);
         m_adaptScreenBtn->setEnabled(true);
 
-        if (!PermissionConfig::instance()->isEditable()) {
+        if (!PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableEdit)) {
             return;
         }
 
@@ -816,9 +816,9 @@ void LibBottomToolbar::initUI()
         auto authIns = PermissionConfig::instance();
 
         if (m_ocrBtn) {
-            m_ocrBtn->setEnabled(authIns->isEditable());
+            m_ocrBtn->setEnabled(authIns->checkAuthFlag(PermissionConfig::EnableEdit));
         }
-        bool isDeletable = authIns->isDeletable();
+        bool isDeletable = authIns->checkAuthFlag(PermissionConfig::EnableDelete);
         m_trashBtn->setVisible(isDeletable);
         m_trashBtn->setEnabled(isDeletable);
     }

--- a/libimageviewer/viewpanel/scen/imagegraphicsview.cpp
+++ b/libimageviewer/viewpanel/scen/imagegraphicsview.cpp
@@ -963,8 +963,8 @@ void LibImageGraphicsView::slotRotatePixCurrent()
                 pathType != imageViewerSpace::PathTypeSAFEBOX && //保险箱
                 pathType != imageViewerSpace::PathTypeRECYCLEBIN) { //回收站
 
-            // 图片信息不一定同步，需做二次判断
-            if (!PermissionConfig::instance()->isEditable(m_path)) {
+            // 图片信息不一定同步，需做二次判断，根据权限配置是否回写文件
+            if (!PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableEdit, m_path)) {
                 m_rotateAngel = 0;
                 return;
             }
@@ -986,7 +986,7 @@ void LibImageGraphicsView::slotRotatePixCurrent()
             m_rotateAngel = 0;
 
             // 通知授权控制图片编辑完成
-            PermissionConfig::instance()->triggerEdit(m_path);
+            PermissionConfig::instance()->triggerAction(PermissionConfig::TidEdit, m_path);
         }
     }
 }

--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -152,6 +152,10 @@ LibViewPanel::LibViewPanel(AbstractTopToolbar *customToolbar, QWidget *parent)
 
 LibViewPanel::~LibViewPanel()
 {
+    // 关闭前保存旋转状态
+    if (m_view) {
+        m_view->slotRotatePixCurrent();
+    }
     // 析构时通知图片窗口关闭
     PermissionConfig::instance()->triggerClose(m_currentPath);
 
@@ -198,6 +202,10 @@ void LibViewPanel::loadImage(const QString &path, QStringList paths)
     QFileInfo targetImageInfo(PermissionConfig::instance()->targetImage());
     if (info.absoluteDir() != targetImageInfo.absoluteDir()) {
         if (!paths.contains(targetImageInfo.absoluteFilePath())) {
+            // 关闭前保存旋转状态
+            if (m_view) {
+                m_view->slotRotatePixCurrent();
+            }
             // 不含授权文件，提示文件关闭
             PermissionConfig::instance()->triggerClose(PermissionConfig::instance()->targetImage());
         }

--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -697,12 +697,14 @@ void LibViewPanel::updateMenuContent(const QString &path)
 
         }
 
-        //需要判断图片是否支持设置壁纸，若不支持则置灰设置壁纸菜单项
-        if (isPic) {
+        // 需要判断图片是否支持设置壁纸，若不支持则置灰设置壁纸菜单项
+        // 当配置权限控制时，屏蔽设置壁纸接口
+        if (isPic && !authIns->isValid()) {
             QAction *ac = appendAction(IdSetAsWallpaper, QObject::tr("Set as wallpaper"), ss("Set as wallpaper", "Ctrl+F9"));
             if (ac)
                 ac->setEnabled(Libutils::image::imageSupportWallPaper(ItemInfo.path));
         }
+        
         if (isReadable) {
             appendAction(IdDisplayInFileManager, QObject::tr("Display in file manager"),
                          ss("Display in file manager", "Alt+D"));

--- a/libimageviewer/viewpanel/viewpanel.h
+++ b/libimageviewer/viewpanel/viewpanel.h
@@ -81,7 +81,7 @@ public:
      * @param text          按钮名称
      * @param shortcut      按钮快捷键
      */
-    QAction *appendAction(int id, const QString &text, const QString &shortcut = "");
+    QAction *appendAction(int id, const QString &text, const QString &shortcut = "", bool enable = true);
 
     //设置壁纸
     void setWallpaper(const QImage &img);

--- a/libimageviewer/widgets/printhelper.cpp
+++ b/libimageviewer/widgets/printhelper.cpp
@@ -191,7 +191,8 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
 #ifndef USE_TEST
     int ret = printDialog2.exec();
 #else
-    int ret = printDialog2.show();
+    printDialog2.show();
+    int ret = QDialog::Accepted;
 #endif
 
    if (QDialog::Accepted == ret) {

--- a/libimageviewer/widgets/printhelper.cpp
+++ b/libimageviewer/widgets/printhelper.cpp
@@ -143,6 +143,11 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
 #endif
 
 #ifdef DTKWIDGET_CLASS_DWaterMarkHelper
+    // 检查是否过滤 DTK 部分设置
+    if (PermissionConfig::instance()->installFilterPrintDialog(&printDialog2)) {
+        qInfo() << qPrintable("Enable breakPrintSpacingLimit, filter print spacing config.");
+    }
+
     // 定制分支，水印功能不依赖DTK版本，更新打印水印设置
     if (PermissionConfig::instance()->hasPrintWaterMark()) {
         auto data = PermissionConfig::instance()->printWaterMarkData();

--- a/libimageviewer/widgets/printhelper.cpp
+++ b/libimageviewer/widgets/printhelper.cpp
@@ -17,6 +17,7 @@
 
 #include <DApplication>
 #include <dprintpreviewsettinginfo.h>
+#include <dtkwidget_config.h>
 
 #ifdef USE_UNIONIMAGE
 #include "printhelper.h"
@@ -141,7 +142,7 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
     }
 #endif
 
-#ifndef DISABLE_WATERMARK
+#ifdef DTKWIDGET_CLASS_DWaterMarkHelper
     // 定制分支，水印功能不依赖DTK版本
     // 更新打印水印设置
     if (PermissionConfig::instance()->hasPrintWaterMark()) {

--- a/libimageviewer/widgets/printhelper.cpp
+++ b/libimageviewer/widgets/printhelper.cpp
@@ -139,8 +139,10 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
             printDialog2.setDocName(QFileInfo(tempExsitPaths.at(0)).absoluteFilePath());
         }
     }
+#endif
 
 #ifndef DISABLE_WATERMARK
+    // 定制分支，水印功能不依赖DTK版本
     // 更新打印水印设置
     if (PermissionConfig::instance()->hasPrintWaterMark()) {
         auto data = PermissionConfig::instance()->printWaterMarkData();
@@ -182,7 +184,6 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
     }
 #endif
 
-#endif
     connect(&printDialog2, SIGNAL(paintRequested(DPrinter *)),
             m_re, SLOT(paintRequestSync(DPrinter *)));
 

--- a/libimageviewer/widgets/printhelper.cpp
+++ b/libimageviewer/widgets/printhelper.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2024 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -24,7 +24,6 @@
 #include "unionimage/unionimage.h"
 #endif
 
-
 PrintHelper *PrintHelper::m_Printer = nullptr;
 
 PrintHelper *PrintHelper::getIntance()
@@ -46,58 +45,6 @@ PrintHelper::~PrintHelper()
     m_re->deleteLater();
 }
 
-//暂时没有使用配置文件的快捷键，现在是根据代码中的快捷键
-/*
-static QAction *hookToolBarActionIcons(QToolBar *bar, QAction **pageSetupAction = nullptr)
-{
-    QAction *last_action = nullptr;
-
-    for (QAction *action : bar->actions()) {
-        const QString &text = action->text();
-
-        if (text.isEmpty())
-            continue;
-
-        // 防止被lupdate扫描出来
-        const char *context = "QPrintPreviewDialog";
-        const char *print = "Print";
-
-        const QMap<QString, QString> map {
-            {QCoreApplication::translate(context, "Next page"), QStringLiteral("go-next")},
-            {QCoreApplication::translate(context, "Previous page"), QStringLiteral("go-previous")},
-            {QCoreApplication::translate(context, "First page"), QStringLiteral("go-first")},
-            {QCoreApplication::translate(context, "Last page"), QStringLiteral("go-last")},
-            {QCoreApplication::translate(context, "Fit width"), QStringLiteral("fit-width")},
-            {QCoreApplication::translate(context, "Fit page"), QStringLiteral("fit-page")},
-            {QCoreApplication::translate(context, "Zoom in"), QStringLiteral("zoom-in")},
-            {QCoreApplication::translate(context, "Zoom out"), QStringLiteral("zoom-out")},
-            {QCoreApplication::translate(context, "Portrait"), QStringLiteral("layout-portrait")},
-            {QCoreApplication::translate(context, "Landscape"), QStringLiteral("layout-landscape")},
-            {QCoreApplication::translate(context, "Show single page"), QStringLiteral("view-page-one")},
-            {QCoreApplication::translate(context, "Show facing pages"), QStringLiteral("view-page-sided")},
-            {QCoreApplication::translate(context, "Show overview of all pages"), QStringLiteral("view-page-multi")},
-            {QCoreApplication::translate(context, print), QStringLiteral("print")},
-            {QCoreApplication::translate(context, "Page setup"), QStringLiteral("page-setup")}
-        };
-
-
-        const QString &icon_name = map.value(action->text());
-
-        if (icon_name.isEmpty())
-            continue;
-
-        if (pageSetupAction && icon_name == "page-setup") {
-            *pageSetupAction = action;
-        }
-
-        QIcon icon(QStringLiteral(":/qt-project.org/dialogs/assets/images/qprintpreviewdialog/images/%1-24.svg").arg(icon_name));
-//        action->setIcon(icon);
-        last_action = action;
-    }
-
-    return last_action;
-}
-*/
 void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
 {
     if (!PermissionConfig::instance()->isPrintable()) {
@@ -108,7 +55,7 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
     m_re->m_imgs.clear();
 
     m_re->m_paths = paths;
-    QStringList tempExsitPaths;//保存存在的图片路径
+    QStringList tempExsitPaths;  // 保存存在的图片路径
     for (const QString &path : paths) {
         QString errMsg;
         QImageReader imgReadreder(path);
@@ -118,7 +65,7 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
                 m_re->m_imgs << imgReadreder.read();
             }
         } else {
-            //QImage不应该多次赋值，所以换到这里来，修复style问题
+            // QImage不应该多次赋值，所以换到这里来，修复style问题
             QImage img;
             LibUnionImage_NameSpace::loadStaticImageFromFile(path, img, errMsg);
             if (!img.isNull()) {
@@ -128,15 +75,14 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
         tempExsitPaths << paths;
     }
 
-    //看图采用同步,因为只有一张图片，传入父指针
-    DPrintPreviewDialog printDialog2(parent);    
-#if (DTK_VERSION_MAJOR > 5 \
-    || (DTK_VERSION_MAJOR >=5 && DTK_VERSION_MINOR > 4) \
-    || (DTK_VERSION_MAJOR >= 5 && DTK_VERSION_MINOR >= 4 && DTK_VERSION_PATCH >= 10))//5.4.4暂时没有合入
-    //增加运行时版本判断
+    // 看图采用同步,因为只有一张图片，传入父指针
+    DPrintPreviewDialog printDialog2(parent);
+#if (DTK_VERSION_MAJOR > 5 || (DTK_VERSION_MAJOR >= 5 && DTK_VERSION_MINOR > 4) ||                                               \
+     (DTK_VERSION_MAJOR >= 5 && DTK_VERSION_MINOR >= 4 && DTK_VERSION_PATCH >= 10))  // 5.4.4暂时没有合入
+    // 增加运行时版本判断
     if (DApplication::runtimeDtkVersion() >= DTK_VERSION_CHECK(5, 4, 10, 0)) {
         if (!tempExsitPaths.isEmpty()) {
-            //直接传递为路径,不会有问题
+            // 直接传递为路径,不会有问题
             printDialog2.setDocName(QFileInfo(tempExsitPaths.at(0)).absoluteFilePath());
         }
     }
@@ -150,7 +96,8 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
 
     // 定制分支，水印功能不依赖DTK版本，更新打印水印设置
     if (PermissionConfig::instance()->hasPrintWaterMark()) {
-        auto data = PermissionConfig::instance()->printWaterMarkData();
+        // 使用适配的水印配置
+        auto data = PermissionConfig::instance()->adapterPrintWaterMarkData();
 
         DPrintPreviewSettingInfo *baseInfo = printDialog2.createDialogSettingInfo(DPrintPreviewWatermarkInfo::PS_Watermark);
         if (baseInfo) {
@@ -158,6 +105,7 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
             if (info) {
                 // 打印水印实现方式同阅读水印略有不同，调整参数以使得效果一致。
                 info->opened = true;
+
                 info->angle = static_cast<int>(data.rotation);
                 info->transparency = static_cast<int>(data.opacity * 100);
                 QFontMetrics fm(data.font);
@@ -168,8 +116,12 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
                 if (textSize.width() > 0) {
                     info->columnSpacing = qMax(0.0, (qreal(data.spacing + textSize.width()) / textSize.width()) - 1.0);
                 }
-                info->layout = data.layout == WaterMarkLayout::Center ? DPrintPreviewWatermarkInfo::Center : DPrintPreviewWatermarkInfo::Tiled;
-                info->currentWatermarkType = (data.type == WaterMarkType::Text) ? DPrintPreviewWatermarkInfo::TextWatermark : DPrintPreviewWatermarkInfo::ImageWatermark;
+                info->layout = (data.layout == PermissionConfig::AdapterWaterMarkData::Center) ?
+                                   DPrintPreviewWatermarkInfo::Center :
+                                   DPrintPreviewWatermarkInfo::Tiled;
+                info->currentWatermarkType = (data.type == PermissionConfig::AdapterWaterMarkData::Text) ?
+                                                 DPrintPreviewWatermarkInfo::TextWatermark :
+                                                 DPrintPreviewWatermarkInfo::ImageWatermark;
                 info->textType = DPrintPreviewWatermarkInfo::Custom;
                 info->customText = data.text;
                 info->textColor = data.color;
@@ -177,6 +129,7 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
                 static const qreal sc_defaultFontSize = 65.0;
                 // 字体使用缩放滑块处理 10%~200%, 默认字体大小为65
                 info->size = int(data.font.pointSizeF() / sc_defaultFontSize * 100);
+
                 printDialog2.updateDialogSettingInfo(info);
             } else {
                 qWarning() << qPrintable("Can't convert DPrintPreviewDialog watermark info.") << baseInfo->type();
@@ -191,16 +144,14 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
         // WaterMarkFrame 和 WaterMarkContentFrame 是DTK窗口中水印设置控件的 objectName
         auto widgetList = printDialog2.findChildren<QWidget *>("WaterMarkFrame");
         widgetList.append(printDialog2.findChildren<QWidget *>("WaterMarkContentFrame"));
-        for (auto wid: widgetList) {
+        for (auto wid : widgetList) {
             wid->setVisible(true);
             wid->setEnabled(false);
         }
-
     }
 #endif
 
-    connect(&printDialog2, SIGNAL(paintRequested(DPrinter *)),
-            m_re, SLOT(paintRequestSync(DPrinter *)));
+    connect(&printDialog2, SIGNAL(paintRequested(DPrinter *)), m_re, SLOT(paintRequestSync(DPrinter *)));
 
 #ifndef USE_TEST
     int ret = printDialog2.exec();
@@ -209,7 +160,7 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
     int ret = QDialog::Accepted;
 #endif
 
-   if (QDialog::Accepted == ret) {
+    if (QDialog::Accepted == ret) {
         if (!tempExsitPaths.isEmpty()) {
             PermissionConfig::instance()->triggerPrint(tempExsitPaths.first());
         }
@@ -224,40 +175,34 @@ RequestedSlot::RequestedSlot(QObject *parent)
     Q_UNUSED(parent)
 }
 
-RequestedSlot::~RequestedSlot()
-{
-
-}
+RequestedSlot::~RequestedSlot() {}
 
 void RequestedSlot::paintRequestSync(DPrinter *_printer)
 {
-    //由于之前再度修改了打印的逻辑，导致了相同图片不在被显示，多余多页tiff来说不合理
+    // 由于之前再度修改了打印的逻辑，导致了相同图片不在被显示，多余多页tiff来说不合理
     QPainter painter(_printer);
     int indexNum = 0;
     for (QImage img : m_imgs) {
         if (!img.isNull()) {
             painter.setRenderHint(QPainter::Antialiasing);
             painter.setRenderHint(QPainter::SmoothPixmapTransform);
-            QRect wRect  = _printer->pageRect();
-            //修复bug98129，打印不完全问题，ratio应该是适应宽或者高，不应该直接适应宽
+            QRect wRect = _printer->pageRect();
+            // 修复bug98129，打印不完全问题，ratio应该是适应宽或者高，不应该直接适应宽
             qreal ratio = 0.0;
             qDebug() << wRect;
             ratio = wRect.width() * 1.0 / img.width();
             if (qreal(wRect.height() - img.height() * ratio) > 0) {
-                painter.drawImage(QRectF(0, abs(qreal(wRect.height() - img.height() * ratio)) / 2,
-                                         wRect.width(), img.height() * ratio), img);
+                painter.drawImage(
+                    QRectF(0, abs(qreal(wRect.height() - img.height() * ratio)) / 2, wRect.width(), img.height() * ratio), img);
             } else {
                 ratio = wRect.height() * 1.0 / img.height();
-                painter.drawImage(QRectF(qreal(wRect.width() - img.width() * ratio) / 2, 0,
-                                         img.width() * ratio, wRect.height()), img);
+                painter.drawImage(QRectF(qreal(wRect.width() - img.width() * ratio) / 2, 0, img.width() * ratio, wRect.height()),
+                                  img);
             }
-
-
         }
         indexNum++;
         if (indexNum != m_imgs.size()) {
             _printer->newPage();
-
         }
     }
     painter.end();

--- a/libimageviewer/widgets/printhelper.h
+++ b/libimageviewer/widgets/printhelper.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2024 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,14 +10,17 @@
 #include <dprintpreviewwidget.h>
 #include <dprintpreviewdialog.h>
 DWIDGET_USE_NAMESPACE
+
 //重构printhelper，因为dtk更新
 //绘制图片处理类
 class RequestedSlot : public QObject
 {
     Q_OBJECT
+
 public:
     explicit RequestedSlot(QObject *parent = nullptr);
     ~RequestedSlot();
+
 private slots:
     void paintRequestSync(DPrinter *_printer);
 
@@ -25,6 +28,7 @@ public:
     QStringList m_paths;
     QList<QImage> m_imgs;
 };
+
 class PrintHelper : public QObject
 {
     Q_OBJECT
@@ -33,14 +37,13 @@ public:
     static PrintHelper *getIntance();
     ~PrintHelper();
 
-    //    static QSize adjustSize(PrintOptionsPage* optionsPage, QImage img, int resolution, const QSize & viewportSize);
-    //    static QPoint adjustPosition(PrintOptionsPage* optionsPage, const QSize& imageSize, const QSize & viewportSize);
     void showPrintDialog(const QStringList &paths, QWidget *parent = nullptr);
 
     RequestedSlot *m_re = nullptr;
+
 private:
     explicit PrintHelper(QObject *parent = nullptr);
     static PrintHelper *m_Printer;
 };
 
-#endif // PRINTHELPER_H
+#endif  // PRINTHELPER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,8 @@ add_definitions( -DUSE_UNIONIMAGE )
 option (USE_TEST "Use TESTS" ON)
 add_definitions( -DUSE_TEST )
 
+ADD_COMPILE_OPTIONS(-fno-access-control)
+
 set(TARGET_NAME image-editor-test)
 set(CMD_NAME image-editor-test)
 set(CMAKE_AUTOMOC ON)

--- a/tests/test_permissionconfig.cpp
+++ b/tests/test_permissionconfig.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <QtTest/QtTest>
+#include <gtest/gtest.h>
+
+#include "service/permissionconfig.h"
+#include "imageengine.h"
+
+class UT_PermissionConfig : public ::testing::Test
+{
+public:
+    void SetUp() override;
+    void TearDown() override;
+};
+
+void UT_PermissionConfig::SetUp()
+{
+    PermissionConfig::instance()->valid = true;
+    PermissionConfig::instance()->targetImagePath.clear();
+    PermissionConfig::instance()->currentImagePath.clear();
+}
+
+void UT_PermissionConfig::TearDown()
+{
+    PermissionConfig::instance()->valid = false;
+}
+
+static QString permission_config()
+{
+    QByteArray permission("{ \"permission\": { \"edit\": true, \"copy\": true, \"setWallpaper\": true, \"pictureSwitch\": true, \"printCount\": 2 } }");
+    return permission.toBase64();
+}
+
+TEST_F(UT_PermissionConfig, parseConfigOption_NormalParam_Pass)
+{
+    QString configParam;
+    QStringList imageList;
+    QString tempPath = QApplication::applicationDirPath() + "/svg.svg";
+    QStringList tmpList {tempPath};
+    QStringList arguments {qApp->arguments().first(), "--config=test", tempPath};
+
+    EXPECT_TRUE(PermissionConfig::instance()->parseConfigOption(arguments, configParam, imageList));
+    EXPECT_EQ(configParam, QString("test"));
+    EXPECT_EQ(imageList, tmpList);
+
+    QStringList arguments2 {qApp->arguments().first(), "--config", "test", tempPath};
+    EXPECT_TRUE(PermissionConfig::instance()->parseConfigOption(arguments2, configParam, imageList));
+    EXPECT_EQ(configParam, QString("test"));
+}
+
+TEST_F(UT_PermissionConfig, parseConfigOption_NormalParam_Fail)
+{
+    QString configParam;
+    QStringList imageList;
+    QString tempPath = QApplication::applicationDirPath() + "/svg.svg";
+    QStringList arguments {qApp->arguments().first(), "config", "test", tempPath};
+
+    EXPECT_FALSE(PermissionConfig::instance()->parseConfigOption({}, configParam, imageList));
+    EXPECT_TRUE(configParam.isEmpty());
+    EXPECT_TRUE(imageList.isEmpty());
+
+    QStringList tmpList {"config", "test", tempPath};
+    EXPECT_FALSE(PermissionConfig::instance()->parseConfigOption(arguments, configParam, imageList));
+    EXPECT_TRUE(configParam.isEmpty());
+    EXPECT_EQ(imageList, tmpList);
+}
+
+TEST_F(UT_PermissionConfig, initFromArguments_NormalParam_Pass)
+{
+    PermissionConfig::instance()->valid = false;
+    PermissionConfig::instance()->authFlags = PermissionConfig::NoAuth;
+
+    QString tempPath = QApplication::applicationDirPath() + "/svg.svg";
+    QStringList args;
+    args << qApp->arguments().first()
+         << QString("--config=%1").arg(permission_config())
+         << tempPath;
+
+    PermissionConfig::instance()->initFromArguments(args);
+    EXPECT_TRUE(PermissionConfig::instance()->isValid());
+
+    PermissionConfig::Authorises auth = PermissionConfig::Authorises(
+        PermissionConfig::EnableCopy | PermissionConfig::EnableEdit | PermissionConfig::EnableSwitch | PermissionConfig::EnableWallpaper);
+    EXPECT_EQ(PermissionConfig::instance()->authFlags, auth);
+    EXPECT_EQ(PermissionConfig::instance()->targetImagePath, tempPath);
+}
+
+TEST_F(UT_PermissionConfig, initFromArguments_NormalParam_Fail)
+{
+    PermissionConfig::instance()->valid = false;
+    PermissionConfig::instance()->authFlags = PermissionConfig::NoAuth;
+
+    PermissionConfig::instance()->initFromArguments({});
+    EXPECT_FALSE(PermissionConfig::instance()->isValid());
+    EXPECT_EQ(PermissionConfig::instance()->authFlags, PermissionConfig::NoAuth);
+    EXPECT_TRUE(PermissionConfig::instance()->targetImagePath.isEmpty());
+}
+
+TEST_F(UT_PermissionConfig, checkAuthFlag_NotInit_Pass)
+{
+    PermissionConfig::instance()->authFlags = PermissionConfig::Authorises(0b11000000111111);
+    EXPECT_TRUE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableEdit));
+    EXPECT_TRUE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableCopy));
+    EXPECT_TRUE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableDelete));
+    EXPECT_TRUE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableRename));
+    EXPECT_TRUE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableSwitch));
+    EXPECT_TRUE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableWallpaper));
+    EXPECT_TRUE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableReadWaterMark));
+    EXPECT_TRUE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnablePrintWaterMark));
+    EXPECT_TRUE(PermissionConfig::instance()->hasReadWaterMark());
+    EXPECT_TRUE(PermissionConfig::instance()->hasPrintWaterMark());
+
+    PermissionConfig::instance()->currentImagePath = "1.png";
+    PermissionConfig::instance()->targetImagePath = "1.png";
+    EXPECT_FALSE(PermissionConfig::instance()->checkAuthInvalid());
+    EXPECT_TRUE(PermissionConfig::instance()->checkAuthInvalid("2.png"));
+}
+
+TEST_F(UT_PermissionConfig, checkAuthFlag_NotInit_Fail)
+{
+    EXPECT_TRUE(PermissionConfig::instance()->valid);
+    PermissionConfig::instance()->authFlags = PermissionConfig::NoAuth;
+    EXPECT_FALSE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableEdit));
+    EXPECT_FALSE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableCopy));
+    EXPECT_FALSE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableDelete));
+    EXPECT_FALSE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableRename));
+    EXPECT_FALSE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableSwitch));
+    EXPECT_FALSE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableWallpaper));
+    EXPECT_FALSE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnableReadWaterMark));
+    EXPECT_FALSE(PermissionConfig::instance()->checkAuthFlag(PermissionConfig::EnablePrintWaterMark));
+    EXPECT_FALSE(PermissionConfig::instance()->hasReadWaterMark());
+    EXPECT_FALSE(PermissionConfig::instance()->hasPrintWaterMark());
+}
+
+TEST_F(UT_PermissionConfig, print_Count_Pass)
+{
+    QString tmpPath("/tmp/tmp.png");
+    PermissionConfig::instance()->targetImagePath = tmpPath;
+
+    PermissionConfig::instance()->printLimitCount = 1;
+    EXPECT_EQ(PermissionConfig::instance()->printLimitCount, 1);
+    EXPECT_TRUE(PermissionConfig::instance()->isPrintable(tmpPath));
+
+    PermissionConfig::instance()->triggerPrint(tmpPath);
+    EXPECT_EQ(PermissionConfig::instance()->printLimitCount, 0);
+    EXPECT_FALSE(PermissionConfig::instance()->isPrintable(tmpPath));
+
+    PermissionConfig::instance()->printLimitCount = -1;
+    EXPECT_TRUE(PermissionConfig::instance()->isPrintable(tmpPath));
+    PermissionConfig::instance()->triggerPrint(tmpPath);
+    EXPECT_EQ(PermissionConfig::instance()->printLimitCount, -1);
+    EXPECT_TRUE(PermissionConfig::instance()->isUnlimitPrint());
+}
+
+TEST_F(UT_PermissionConfig, watarMark_JsonData_Pass)
+{
+    // Default value
+    auto markData = PermissionConfig::instance()->readWaterMarkData();
+    EXPECT_EQ(markData.type, WaterMarkType::None);
+    EXPECT_EQ(markData.opacity, 1);
+    EXPECT_EQ(markData.layout, WaterMarkLayout::Center);
+    EXPECT_TRUE(markData.text.isEmpty());
+
+    QJsonObject param {{"text", "test"}, {"opacity", 0}, {"layout", 1}};
+
+    PermissionConfig::instance()->initReadWaterMark(param);
+    markData = PermissionConfig::instance()->readWaterMarkData();
+    EXPECT_EQ(markData.type, WaterMarkType::Text);
+    EXPECT_EQ(markData.opacity, 0);
+    EXPECT_EQ(markData.layout, WaterMarkLayout::Tiled);
+    EXPECT_EQ(markData.text, QString("test"));
+
+    PermissionConfig::instance()->initPrintWaterMark(param);
+    markData = PermissionConfig::instance()->printWaterMarkData();
+    EXPECT_EQ(markData.type, WaterMarkType::Text);
+}
+
+TEST_F(UT_PermissionConfig, triggerAction_SignalNotify_Pass)
+{
+    QJsonObject notifyData;
+    QObject::connect(PermissionConfig::instance(), &PermissionConfig::authoriseNotify, [&](const QJsonObject &notify){
+        notifyData = notify;
+    });
+
+    auto TriggerFunction = [&](PermissionConfig::TidType tid, const QString &operate){
+        // PermissionConfig::targetImagePath is empty.
+        PermissionConfig::instance()->triggerAction(tid, "");
+        // ReportMode::ReportAndBroadcast = 0b11
+        auto policyData = notifyData.value("policy").toObject();
+        EXPECT_EQ(policyData.value("reportMode").toInt(), 3);
+
+        QJsonObject data = notifyData.value("info").toObject();
+        EXPECT_EQ(data.value("tid").toInt(), tid);
+        EXPECT_EQ(data.value("operate").toString(), operate);
+    };
+
+    PermissionConfig::instance()->status = PermissionConfig::NotOpen;
+
+    TriggerFunction(PermissionConfig::TidOpen, "open");
+    TriggerFunction(PermissionConfig::TidEdit, "edit");
+    TriggerFunction(PermissionConfig::TidCopy, "copy");
+    // Close will set PermissionConfig::valid to false.
+    TriggerFunction(PermissionConfig::TidClose, "close");
+    EXPECT_FALSE(PermissionConfig::instance()->isValid());
+    EXPECT_EQ(PermissionConfig::instance()->status, PermissionConfig::Close);
+}
+
+


### PR DESCRIPTION
合并权限控制和水印需求到主线.
涉及提交 https://github.com/linuxdeepin/image-editor/commit/807a3b3a84d6c76e60d8fa216229dbdfd04ea732
到 https://github.com/linuxdeepin/image-editor/commit/31bae041cdaad3045fe8d15f33b4d0d9cc8751fd

* 新增权限控制功能, 允许配置功能开闭;
* 新增水印功能, 允许通过配置定制阅读和打印水印;
* 水印接口特殊, DTKWidget主线和定制线的接口不同.

Log: 回合看图权限控制和水印需求
Task: https://pms.uniontech.com/story-view-27785.html
Task: https://pms.uniontech.com/story-view-30217.html
Influence: Print Permission