### PR TITLE
chore: Bump version to 1.0.43

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+image-editor (1.0.43) unstable; urgency=medium
+
+  * fix: Info widget flicking on wayland.(Bug: 242125)
+
+ -- renbin <renbin@uniontech.com>  Wed, 21 Feb 2024 16:50:55 +0800
+
 image-editor (1.0.42) unstable; urgency=medium
 
   * fix: Fixed the issue where the thumbnail display would be


### PR DESCRIPTION
Bump version to 1.0.43
PR:
* https://github.com/linuxdeepin/image-editor/pull/128

Log: Bump version to 1.0.43