### PR TITLE
fix: Cached greeter background image too large

### DIFF
--- a/libimageviewer/unionimage/imageutils.cpp
+++ b/libimageviewer/unionimage/imageutils.cpp
@@ -782,9 +782,15 @@ bool imageSupportWallPaper(const QString &path)
    @return 返回文件类型是否可以直接设置锁屏壁纸
         壁纸支持 jpeg jpg png bmp tif gif
         锁屏支持 jpeg jpg png
+        且允许直接设置的图片大小不超过5MB (后端限制<32MB)
  */
 bool imageSupportGreeterDirect(const QString &path)
 {
+    static qint64 s_maxFileSize = 5 * 1024 * 1024;
+    if (QFileInfo(path).size() > s_maxFileSize) {
+        return false;
+    }
+
     QMimeDatabase db;
     QMimeType mt = db.mimeTypeForFile(path, QMimeDatabase::MatchDefault);
     return "image/jpeg" == mt.name() || "image/png" == mt.name();

--- a/libimageviewer/viewpanel/viewpanel.cpp
+++ b/libimageviewer/viewpanel/viewpanel.cpp
@@ -883,13 +883,14 @@ static void setWallpaperWithDBus(const QString &path)
 void LibViewPanel::setWallpaper(const QImage &img)
 {
     if (!img.isNull()) {
-        QString tempPathTemplate = Libutils::image::getCacheImagePath() + QDir::separator() + "XXXXXX_Wallpaper.png";
+        QString tempPathTemplate = Libutils::image::getCacheImagePath() + QDir::separator() + "XXXXXX_Wallpaper.jpg";
         QThread *th1 = QThread::create([ = ]() {
             // 设置锁屏壁纸不能使用相同名称，且临时文件不能立即删除(调用DBus接口拷贝需要时间)，保留至缓存目录，程序退出自动清理
             QTemporaryFile tmpImage;
             tmpImage.setAutoRemove(false);
             tmpImage.setFileTemplate(tempPathTemplate);
-            if (!tmpImage.open() || !img.save(tmpImage.fileName(), "PNG")) {
+            // 使用JPG压缩而不是PNG以压缩减少缓存图片大小
+            if (!tmpImage.open() || !img.save(tmpImage.fileName(), "JPG")) {
                 qWarning() << QString("Copy image set wallpaper failed! path: %1").arg(tmpImage.fileName());
                 return;
             }


### PR DESCRIPTION
设置锁屏背景的图片过大,后端DBus可能返回文件过大错误,
调整压缩格式PNG为JPG,同时过大的PNG/JPG图片也会被压缩.

Log: 修复设置大图片为壁纸无反应的问题
Bug: https://pms.uniontech.com/bug-view-247311.html
Influence: SetWallpaper