### PR TITLE
feat: disable tiff picture auto transform

### DIFF
--- a/libimageviewer/quickprint/printimageloader.cpp
+++ b/libimageviewer/quickprint/printimageloader.cpp
@@ -269,6 +269,13 @@ bool PrintImageLoader::loadImageData(PrintImageData::Ptr &imagePtr)
             }
         } else {
             QImageReader reader(imagePtr->filePath);
+
+            // TIFF 图片不根据EXIF信息旋转
+            QString format = reader.format().toLower();
+            if ("tiff" == format || "tif" == format) {
+                reader.setAutoTransform(false);
+            }
+
             // jumpToImage 可能返回 false, 但数据正常读取
             reader.jumpToImage(imagePtr->frame);
             if (!reader.canRead()) {

--- a/libimageviewer/unionimage/unionimage.cpp
+++ b/libimageviewer/unionimage/unionimage.cpp
@@ -666,7 +666,9 @@ UNIONIMAGESHARED_EXPORT bool loadStaticImageFromFile(const QString &path, QImage
         } else {
             reader.setFormat(format_bar.toLatin1());
         }
-        reader.setAutoTransform(true);
+        // Tiff 图片不根据EXIF信息旋转
+        reader.setAutoTransform(FIF_TIFF != f);
+
         if (reader.imageCount() > 0 || file_suffix_upper != "ICNS") {
             res_qt = reader.read();
             if (res_qt.isNull()) {
@@ -674,7 +676,8 @@ UNIONIMAGESHARED_EXPORT bool loadStaticImageFromFile(const QString &path, QImage
                 QString format = PrivateDetectImageFormat(path);
                 QImageReader readerF(path, format.toLatin1());
                 QImage try_res;
-                readerF.setAutoTransform(true);
+                readerF.setAutoTransform(FIF_TIFF != f);
+
                 if (readerF.canRead()) {
                     try_res = readerF.read();
                 } else {

--- a/libimageviewer/viewpanel/scen/imagegraphicsview.cpp
+++ b/libimageviewer/viewpanel/scen/imagegraphicsview.cpp
@@ -834,7 +834,20 @@ void LibImageGraphicsView::slotsUp()
             scene()->clear();
 
             resetTransform();
-            QPixmap pixmap = QPixmap::fromImage(m_imageReader->read());
+            QPixmap pixmap;
+
+            // FIXME: 临时修改，TIFF 图片不根据EXIF信息旋转
+            // 且由于 libqtiff 插件缓存的旋转信息可能错误，缓存数据会导致内存占用升高，调整为单次新建读取
+            QString format = m_imageReader->format().toLower();
+            if ("tiff" == format || "tif" == format) {
+                QImageReader tmpReader(m_imageReader->fileName());
+                tmpReader.setAutoTransform(false);
+                tmpReader.jumpToImage(m_imageReader->currentImageNumber());
+                pixmap = QPixmap::fromImage(tmpReader.read());
+            } else {
+                pixmap = QPixmap::fromImage(m_imageReader->read());
+            }
+
             pixmap.setDevicePixelRatio(devicePixelRatioF());
             m_pixmapItem = new LibGraphicsPixmapItem(pixmap);
             scene()->addItem(m_pixmapItem);
@@ -884,7 +897,20 @@ void LibImageGraphicsView::slotsDown()
             m_imgSvgItem = nullptr;
             scene()->clear();
             resetTransform();
-            QPixmap pixmap = QPixmap::fromImage(m_imageReader->read());
+            QPixmap pixmap;
+
+            // FIXME: 临时修改，TIFF 图片不根据EXIF信息旋转
+            // 且由于 libqtiff 插件缓存的旋转信息可能错误，缓存数据会导致内存占用升高，调整为单次新建读取
+            QString format = m_imageReader->format().toLower();
+            if ("tiff" == format || "tif" == format) {
+                QImageReader tmpReader(m_imageReader->fileName());
+                tmpReader.setAutoTransform(false);
+                tmpReader.jumpToImage(m_imageReader->currentImageNumber());
+                pixmap = QPixmap::fromImage(tmpReader.read());
+            } else {
+                pixmap = QPixmap::fromImage(m_imageReader->read());
+            }
+
             pixmap.setDevicePixelRatio(devicePixelRatioF());
             m_pixmapItem = new LibGraphicsPixmapItem(pixmap);
             scene()->addItem(m_pixmapItem);

--- a/libimageviewer/widgets/printhelper.cpp
+++ b/libimageviewer/widgets/printhelper.cpp
@@ -57,6 +57,13 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
     for (const QString &path : paths) {
         QString errMsg;
         QImageReader imgReadreder(path);
+
+        // TIFF 图片不根据EXIF信息旋转
+        QString format = imgReadreder.format().toLower();
+        if ("tiff" == format || "tif" == format) {
+            imgReadreder.setAutoTransform(false);
+        }
+
         if (imgReadreder.imageCount() > 1) {
             for (int imgindex = 0; imgindex < imgReadreder.imageCount(); imgindex++) {
                 imgReadreder.jumpToImage(imgindex);


### PR DESCRIPTION
禁用TIFF图片自动根据EXIF信息旋转；
且由于 libqtiff 插件缓存的旋转信息可能错误，
缓存数据会导致内存占用升高，调整为每次读取
TIFF图片数据。

Log: 调整TIFF图片默认展示效果
Influence: ImageView Print