### PR TITLE
fix: 修复ftp共享目录图片打开显示空白

### DIFF
--- a/libimageviewer/viewpanel/scen/imagegraphicsview.cpp
+++ b/libimageviewer/viewpanel/scen/imagegraphicsview.cpp
@@ -42,6 +42,8 @@
 
 #include <DGuiApplicationHelper>
 #include <DApplicationHelper>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
 
 #ifndef QT_NO_OPENGL
 //#include <QGLWidget>
@@ -78,6 +80,31 @@ QVariantList cachePixmap(const QString &path)
     if (QFileInfo(path).exists() && p.isNull()) {
         //判定为损坏图片
 //        p = utils::image::getDamagePixmap(DApplicationHelper::instance()->themeType() == DApplicationHelper::LightType);
+        if(path.contains("ftp:host=")) {//前面失败后再处理ftp图片
+            QFileInfo info(path);
+            if(info.size() <=  1024*1024*1024) {//小于1Mftp文件做下载本地处理
+                QNetworkAccessManager manager;
+                QTemporaryFile tmpfile;
+                QEventLoop loop;
+
+                QObject::connect(&manager, &QNetworkAccessManager::finished, [&](QNetworkReply *reply){
+                     if (tmpfile.open()) {
+                        tmpfile.write(reply->readAll()); // 写入到目标文件
+                        tmpfile.flush();
+                        loop.quit();
+                    }
+                });
+                int nIdex = path.indexOf("ftp:host=");
+                QString urlAddr = path.mid(nIdex).replace("ftp:host=", "ftp://");
+                QNetworkRequest request(urlAddr);
+                manager.get(request);
+                loop.exec();
+                QString strNewFile = tmpfile.fileName();
+                LibUnionImage_NameSpace::loadStaticImageFromFile(strNewFile, tImg, errMsg);
+                p = QPixmap::fromImage(tImg);
+                tmpfile.close();
+            }
+        }
         qDebug() << errMsg;
     }
     QVariantList vl;


### PR DESCRIPTION
修复ftp共享目录图片打开显示空白

Bug: https://pms.uniontech.com/bug-view-275425.html
Log: 修复ftp共享目录图片打开显示空白