### PR TITLE
fix:  Depends error | chore: Bump version to 6.5.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+image-editor (6.5.1) unstable; urgency=medium
+
+  * fix: support multi frame image load(Influence: quickprint)
+  * test: Add initFFmpegVideoThumbnailer unit test.
+          (Bug: 213565, 221557)(Influence: VideoThumbnailer)
+  * test: update test image path
+  * feat: [translation]add transifex config(Task: 361363)
+  * fix: Update build configuration and dependencies
+
+ -- renbin <renbin@uniontech.com>  Thu, 17 Apr 2025 13:23:01 +0800
+
 image-editor (6.5.0) unstable; urgency=medium
 
   * fix: Use common method to check the version of dtkwidget

--- a/debian/control
+++ b/debian/control
@@ -51,7 +51,7 @@ Build-Depends:
 Standards-Version: 3.9.8
 Homepage: http://www.deepin.org
 
-# Support Qt5
+# Support Qt6
 Package: libimageeditor6
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
@@ -65,7 +65,7 @@ Description: Image Viewer library.
 
 Package: libimageeditor6-dev
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libimageeditor(=${binary:Version})
+Depends: ${shlibs:Depends}, ${misc:Depends}, libimageeditor6(=${binary:Version})
 Conflicts:
  libimage-viewer-dev
 Replaces:


### PR DESCRIPTION
[fix: Update build configuration and dependencies](https://github.com/linuxdeepin/image-editor/pull/161/commits/fa1fb15f87d219a58c36b5ea65a179e15e4d1745)
1. Updated comment from Qt5 to Qt6 support
2. Fixed libimageeditor6-dev dependency name

Log: Fix package build and installation

[chore: Bump version to 6.5.1](https://github.com/linuxdeepin/image-editor/pull/161/commits/29751a1b0f0359cebc53d52c9ea8373a7a9fb568)

Bump version to 6.5.1

Log: Bump version to 6.5.1