### PR TITLE
fix(image): detect image format by content instead of suffix

### DIFF
--- a/libimageviewer/unionimage/unionimage.cpp
+++ b/libimageviewer/unionimage/unionimage.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -197,6 +197,9 @@ UNIONIMAGESHARED_EXPORT QString size2Human(const qlonglong bytes)
     }
 }
 
+// Forward declaration for PrivateDetectImageFormat
+QString PrivateDetectImageFormat(const QString &filepath);
+
 /**
  * @brief getFileFormat
  * @param path
@@ -206,9 +209,15 @@ UNIONIMAGESHARED_EXPORT QString size2Human(const qlonglong bytes)
  */
 UNIONIMAGESHARED_EXPORT const QString getFileFormat(const QString &path)
 {
-    QFileInfo fi(path);
-    QString suffix = fi.suffix();
-    return suffix;
+    // 先尝试通过文件内容检测格式，避免修改后缀后无法正常打开图片的问题
+    QString format = PrivateDetectImageFormat(path);
+    if (format.isEmpty()) {
+        // 如果内容检测失败，回退到后缀名判断
+        QFileInfo fi(path);
+        QString suffix = fi.suffix();
+        return suffix;
+    }
+    return format;
 }
 
 UNIONIMAGESHARED_EXPORT bool canSave(const QString &path)


### PR DESCRIPTION
Prioritize content-based format detection to support opening images with modified file extensions.

优先通过文件内容检测格式，支持打开修改后缀的图片文件。

Log: 修复修改后缀后图片无法打开的问题
PMS: BUG-355941
Influence: 修改文件后缀的图片现在可以正常打开，提升用户体验。