### PR TITLE
fix(unionimage): rotate TIFF and SVG images correctly

### DIFF
--- a/libimageviewer/unionimage/unionimage.cpp
+++ b/libimageviewer/unionimage/unionimage.cpp
@@ -117,7 +117,9 @@ public:
                    << "PPM"
                    << "XPM"
                    << "ICO"
-                   << "ICNS";
+                   << "ICNS"
+                   << "TIF"
+                   << "TIFF";
     }
     ~UnionImage_Private()
     {
@@ -517,9 +519,13 @@ UNIONIMAGESHARED_EXPORT bool rotateImageFIle(int angel, const QString &path, QSt
             erroMsg = "rotate load QImage failed, path:" + path + "  ,format:+" + format;
             return false;
         }
+        const QSize rotatedSize = qAbs(angel / 90) % 2 == 0
+                ? image_copy.size()
+                : QSize(image_copy.height(), image_copy.width());
         QSvgGenerator generator;
         generator.setFileName(path);
-        generator.setViewBox(QRect(0, 0, image_copy.width(), image_copy.height()));
+        generator.setSize(rotatedSize);
+        generator.setViewBox(QRect(QPoint(0, 0), rotatedSize));
         QPainter rotatePainter;
         rotatePainter.begin(&generator);
         rotatePainter.resetTransform();
@@ -527,18 +533,17 @@ UNIONIMAGESHARED_EXPORT bool rotateImageFIle(int angel, const QString &path, QSt
         int realangel = angel / 90;
         if (realangel > 0) {
             for (int i = 0; i < qAbs(realangel); i++) {
-                rotatePainter.translate(image_copy.width(), 0);
+                rotatePainter.translate(image_copy.height(), 0);
                 rotatePainter.rotate(90 * (realangel / qAbs(realangel)));
             }
         } else {
             for (int i = 0; i < qAbs(realangel); i++) {
-                rotatePainter.translate(0, image_copy.height());
+                rotatePainter.translate(0, image_copy.width());
                 rotatePainter.rotate(90 * (realangel / qAbs(realangel)));
             }
         }
         rotatePainter.drawImage(image_copy.rect(), image_copy.scaled(image_copy.width(), image_copy.height()));
         rotatePainter.resetTransform();
-        generator.setSize(QSize(image_copy.width(), image_copy.height()));
         rotatePainter.end();
         return true;
     } else if (union_image_private.m_qtrotate.contains(format)) {

--- a/tests/test_unionimage.cpp
+++ b/tests/test_unionimage.cpp
@@ -5,6 +5,7 @@
 #include "gtestview.h"
 #include "accessibility/ac-desktop-define.h"
 #include <DGuiApplicationHelper>
+#include <QSvgRenderer>
 #include "imageviewer.h"
 #include "imageengine.h"
 #include "service/imagedataservice.h"
@@ -73,6 +74,22 @@ TEST_F(gtestview, image_rotateNormal45)
 {
     bool bRet = Libutils::image::rotate(QApplication::applicationDirPath() + "/test/jpg170.jpg", 45);
     EXPECT_EQ(false, bRet);
+}
+
+TEST_F(gtestview, image_rotateTiff)
+{
+    bool bRet = Libutils::image::rotate(m_TIFPath, 90);
+    EXPECT_EQ(true, bRet);
+}
+
+TEST_F(gtestview, image_rotateSvg)
+{
+    bool bRet = Libutils::image::rotate(m_SVGPath, 90);
+    EXPECT_EQ(true, bRet);
+
+    QSvgRenderer renderer(m_SVGPath);
+    EXPECT_EQ(3610, renderer.defaultSize().width());
+    EXPECT_EQ(2761, renderer.defaultSize().height());
 }
 
 TEST_F(gtestview, image_thumbnailExist)


### PR DESCRIPTION
## Summary

- Add TIF/TIFF to the Qt rotation format list.
- Resize SVG output canvases for quarter-turn rotations.
- Add TIFF and SVG rotation regression tests.

## Verification

- Main CMake build succeeded.
- The full test-target build remains blocked by the pre-existing missing LibImageGraphicsView::OnFinishPinchAnimal() reference in tests/test_LibImageGraphicsView.cpp:232.

PMS: BUG-283037